### PR TITLE
Checkboxのエラーのスタイルのトンマナを他のフォーム部品と合わせる

### DIFF
--- a/src/components/form/CCheckbox.vue
+++ b/src/components/form/CCheckbox.vue
@@ -68,8 +68,19 @@ const iconClass = computed(() => {
         'peer-disabled:text-gray-400 peer-hover:bg-gray-50 peer-hover:peer-disabled:bg-transparent',
         iconDisplayStatus.value === 'blank' ? 'text-[var(--jupiter-black)]' : iconColor.value,
         props.readonly ? 'peer-read-only:text-gray-500' : '',
-        props.error ? 'bg-red-100' : '',
+        props.error ? 'text-[var(--jupiter-danger-text)]' : '',
     ]
+})
+
+const labelClass = computed(() => {
+    const base = [
+        'text-base peer-disabled:text-gray-400',
+    ]
+    if(props.readonly) base.push('text-gray-500')
+    if(props.error) base.push('text-[var(--jupiter-danger-text)]')
+    if(!props.readonly && !props.error) base.push('text-[var(--jupiter-black)]')
+
+    return base
 })
 
 const indeterminateClick = () => {
@@ -98,7 +109,7 @@ const indeterminateClick = () => {
             <c-svg-icon v-if="iconDisplayStatus==='blank'" :icon="mdiCheckboxBlankOutline"/>
             <c-svg-icon v-if="iconDisplayStatus==='indeterminate'" :icon="mdiMinusBox" />
         </div>
-        <div class="text-base peer-disabled:text-gray-400" :class="readonly?'text-gray-500':'text-[var(--jupiter-black)]'">
+        <div :class="labelClass">
             {{ label }}
         </div>
     </label>


### PR DESCRIPTION
#47 

Checkboxのpropsのerrorがtrueの時のレイアウトを修正しました。

<img width="599" alt="スクリーンショット 2023-03-23 17 06 49" src="https://user-images.githubusercontent.com/101681088/227140953-c84c93eb-530f-461f-99d6-80f225113a8f.png">
<img width="602" alt="スクリーンショット 2023-03-23 17 06 55" src="https://user-images.githubusercontent.com/101681088/227140963-34157025-df7a-4f91-ac21-0bfcd9dda874.png">


## 他ブラウザで確認済み

- Google Chrome
- FireFox
- Edge
- Safari
- Android Emulator
- iPhone Simulator