### PR TITLE
CSelectを使用したときに、項目選択した後にplaceholderが横に表示される

### DIFF
--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -95,9 +95,9 @@ const inputClass = computed(() => {
     const base = [
         'peer w-full focus:outline-none bg-transparent',
     ]
-    if(!props.label) base.push('placeholder:opacity-100')
+    if(props.modelValue || props.modelValue.length) base.push('placeholder:opacity-0')
+    if(!props.label && (!props.modelValue || !props.modelValue.length)) base.push('placeholder:opacity-100')
     if(props.label && (!props.modelValue || !props.modelValue.length)) base.push('placeholder:opacity-0 focus:placeholder:opacity-100')
-    if(props.label && (props.modelValue || props.modelValue.length)) base.push('placeholder:opacity-0')
     if(props.variant === 'filled') base.push('pt-4 pb-1')
     if(props.variant === 'outlined') base.push('pt-4 pb-1.5')
     if(props.variant === 'underlined') base.push('pt-2.5 pb-1')


### PR DESCRIPTION
#102 

ラベルがない時に、項目を選択した時、placeholderが消えないバグを修正しました。

<img width="629" alt="スクリーンショット 2023-04-14 16 32 02" src="https://user-images.githubusercontent.com/101681088/231975659-78cbdd78-04da-4976-9968-511556055e53.png">

### 各ブラウザで確認済み
- Google Chrome
- FireFox
- Edge
- Safari
- Android Emulator
- iPhone Simulator