### PR TITLE
「はじめに」ページに、nuxtの場合の手順を載せる

### DIFF
--- a/src/Introduction.story.md
+++ b/src/Introduction.story.md
@@ -38,6 +38,16 @@ npm install @mdi/js
 import '@actier-luchta/cuv/style'
 ```
 
+### Nuxtで使用する場合
+`plugins`ディレクトリの下に、`cuv.ts`ファイルを作成します
+```ts
+import '@actier-luchta/cuv/style'
+
+export default defineNuxtPlugin((nuxtApp) => {
+
+})
+```
+
 ### リンク
 * [リリースノート](https://github.com/actier-luchta/cuv/releases/)
 * [リポジトリ](https://github.com/actier-luchta/cuv/)

--- a/src/Introduction.story.md
+++ b/src/Introduction.story.md
@@ -38,13 +38,12 @@ npm install @mdi/js
 import '@actier-luchta/cuv/style'
 ```
 
-### Nuxtで使用する場合
-`plugins`ディレクトリの下に、`cuv.ts`ファイルを作成します
+#### Nuxtで使用する場合
+`plugins`ディレクトリの下に、`cuv.ts`ファイルを作成し、ライブラリのスタイルシートをimportします
 ```ts
 import '@actier-luchta/cuv/style'
 
 export default defineNuxtPlugin((nuxtApp) => {
-
 })
 ```
 


### PR DESCRIPTION
#105 

Nuxtプロジェクトの場合に、`はじめに`ページの記述が不足していたため、
`はじめに`ページに、手順を追加しました。

<img width="1240" alt="スクリーンショット 2023-04-18 10 29 17" src="https://user-images.githubusercontent.com/101681088/232646160-a7f5bcb2-3a26-4245-b266-86d3fc3f2d20.png">
