### PR TITLE
CSelect / CCheckbox: modelvalueが配列とそうでない場合の対応をする

### DIFF
--- a/src/components/form/CCheckbox.vue
+++ b/src/components/form/CCheckbox.vue
@@ -47,8 +47,8 @@ const checkboxValue = computed({
 
 const iconDisplayStatus = computed(() => {
     if(data.isIndeterminate) return 'indeterminate'
-    if(typeof props.modelValue === 'boolean') return checkboxValue.value ? 'marked' : 'blank'
-    return checkboxValue.value.includes(props.value) ? 'marked' : 'blank'
+    if(Array.isArray(props.modelValue)) return checkboxValue.value.includes(props.value) ? 'marked' : 'blank'
+    return checkboxValue.value ? 'marked' : 'blank'
 })
 
 const formatedErrorMessage = computed(() => {

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -95,7 +95,7 @@ const inputClass = computed(() => {
     const base = [
         'peer w-full focus:outline-none bg-transparent',
     ]
-    if(props.modelValue || props.modelValue.length) base.push('placeholder:opacity-0')
+    if(props.modelValue || Array.isArray(props.modelValue)) base.push('placeholder:opacity-0')
     if(!props.label && (!props.modelValue || !props.modelValue.length)) base.push('placeholder:opacity-100')
     if(props.label && (!props.modelValue || !props.modelValue.length)) base.push('placeholder:opacity-0 focus:placeholder:opacity-100')
     if(props.variant === 'filled') base.push('pt-4 pb-1')
@@ -182,8 +182,10 @@ const selectionSlotDisplay = computed(() => {
 })
 
 const liClass= (item:any) => {
-    if(props.multiple && props.items[0][props.itemValue]) return props.modelValue.includes(item[props.itemValue]) ? 'bg-blue-50 text-blue-700':''
-    if(props.multiple && !props.items[0][props.itemValue]) return props.modelValue.includes(item) ? 'bg-blue-50 text-blue-700':''
+    if(Array.isArray(props.modelValue)) {
+        if(props.multiple && props.items[0][props.itemValue]) return props.modelValue.includes(item[props.itemValue]) ? 'bg-blue-50 text-blue-700':''
+        if(props.multiple && !props.items[0][props.itemValue]) return props.modelValue.includes(item) ? 'bg-blue-50 text-blue-700':''
+    }
     return item == selectionItem.value ? 'bg-blue-50 text-blue-700':''
 }
 


### PR DESCRIPTION
#109 

CSelectコンポーネントとCCheckboxコンポーネントの、propsのmodelValueが配列の時とそうでない時の、分岐が不足してバグが発生したので、その修正を行いました。

(見た目の変更はありません)