### PR TITLE
CSelect・CAutocomplete: ダイアログの中で利用したときにOptionのリストがOverlayの下に潜り込んでしまう

### DIFF
--- a/src/components/containment/CTooltip.vue
+++ b/src/components/containment/CTooltip.vue
@@ -68,15 +68,6 @@ const close = () => {
     isActive.value = false
 }
 
-const teleportTarget = computed(() => {
-    if (typeof window === 'undefined') return undefined
-    const targetElement = document.body
-    const container = document.createElement('div')
-    container.className = 'c-overlay-container'
-    targetElement.appendChild(container)
-    return container
-})
-
 const tooltipHeight = computed(() => {
     const tooltipElement = content.value
     if ( !tooltipElement ) return 0
@@ -122,7 +113,7 @@ const positionTop = () => {
     >
         <slot name="activator"/>
     </div>
-    <Teleport :to="teleportTarget">
+    <Teleport to="body">
         <span 
         ref="content"
         :class="computedClass" 

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, reactive,  watchEffect } from 'vue'
+import { computed, reactive,  ref,  watchEffect } from 'vue'
 import { mdiMenuDown, mdiMenuUp, mdiClose } from '@mdi/js';
 import CSvgIcon from '@/components/images/CSvgIcon.vue';
 
@@ -51,6 +51,21 @@ const data: {
     isActive: false,
     isHover: false,
     inputText: '',
+})
+
+const componentRef = ref<HTMLElement>()
+const fieldEl = ref<HTMLElement>()
+const inputRef = ref<HTMLElement>()
+const optionsRef = ref<HTMLElement>()
+
+const optionsPosition: {
+    top: string
+    left: string
+    width: string
+} = reactive({
+    top: '',
+    left: '',
+    width: '',
 })
 
 const formatedErrorMessage = computed(() => {
@@ -156,6 +171,15 @@ const selectionSlotDisplay = computed(() => {
     return props.itemValue ? Object.keys(selectionItem).length : selectionItem.value!==''
 })
 
+const teleportTarget = computed(() => {
+    if (typeof window === 'undefined') return undefined
+    const targetElement = document.body
+    const container = document.createElement('div')
+    container.className = 'c-overlay-container'
+    targetElement.appendChild(container)
+    return container
+})
+
 const liClass= (item:any) => {
     if(props.itemValue) return item[props.itemValue]==selectionItem.value[props.itemValue]?'bg-blue-50 text-blue-700':''
     return item == selectionItem.value ? 'bg-blue-50 text-blue-700':''
@@ -190,17 +214,59 @@ const clear = () => {
     if(data.inputText) data.inputText = ''
 }
 
+const optionsMouseOver = () => {
+    data.isHover = true
+    if ( !inputRef.value ) return
+    inputRef.value.focus()
+}
+
+const optionClass = () => {
+    if ( !fieldEl.value ) return
+    if ( typeof window == 'undefined' ) return
+    if ( !optionsRef.value ) return
+    const allElementHeight = fieldEl.value.getBoundingClientRect().top + fieldEl.value.clientHeight + optionsRef.value.clientHeight
+    if ( allElementHeight >= window.innerHeight ) optionsPosition.top = fieldEl.value.getBoundingClientRect().top - optionsRef.value.clientHeight - 10 + 'px'
+    else optionsPosition.top = fieldEl.value.getBoundingClientRect().top + fieldEl.value.clientHeight + 1 + 'px'
+    optionsPosition.left = fieldEl.value.getBoundingClientRect().left+'px'
+    optionsPosition.width = fieldEl.value.clientWidth+'px'
+}
+
+const getScrollParent = (el?: HTMLElement) => {
+    while (el) {
+        if (hasScrollbar(el)) return el
+        el = el.parentElement!
+    }
+
+    return document.scrollingElement as HTMLElement
+}
+
+const hasScrollbar = (el?: Element | null) => {
+    if (!el || el.nodeType !== Node.ELEMENT_NODE) return false
+
+    const style = window.getComputedStyle(el)
+    return style.overflowY === 'scroll' || (style.overflowY === 'auto' && el.scrollHeight > el.clientHeight)
+}
+
 watchEffect(() => {
     if(data.inputText) emits('update:modelValue', '')
+    if ( data.isActive ) {
+        optionClass()
+        const scrollParent = getScrollParent(componentRef.value)
+        scrollParent.onscroll = () => {
+            data.isActive = false
+            if ( !inputRef.value ) return
+            inputRef.value.blur()
+        }
+    }
 })
 
 </script>
 <template>
-<div @mouseover="data.isHover = true" @mouseleave="data.isHover = false" class="relative grid grid-cols-[auto_1fr_auto] gap-y-1">
+<div ref="componentRef" @mouseover="data.isHover = true" @mouseleave="data.isHover = false" class="relative grid grid-cols-[auto_1fr_auto] gap-y-1">
     <div v-show="prependIcon" class="text-lg col-start-1 my-auto pt-1.5 pr-1">
         <c-svg-icon :icon="prependIcon" @click="$emit('click:prepend')" size="medium" class="cursor-pointer" :class="error?'text-[var(--cuv-danger-text)]':'text-gray-500'"/>
     </div>
-    <div :class="fieldClass">
+    <div :class="fieldClass" ref="fieldEl">
         <div v-show="prependInnerIcon" class="my-auto pt-2 pr-2 text-lg">
             <c-svg-icon :icon="prependInnerIcon" @click="$emit('click:prependInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--cuv-danger-text)]':'text-gray-500'"/>
         </div>
@@ -224,6 +290,7 @@ watchEffect(() => {
                 :placeholder="placeholder"
                 :class="inputClass"
                 autocomplete="off"
+                ref="inputRef"
             />
             <label
                 :class="labelClass"
@@ -242,22 +309,6 @@ watchEffect(() => {
             <c-svg-icon :icon="appendInnerIcon" @click="$emit('click:appendInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--cuv-danger-text)]':'text-gray-500'"/>
         </div>
 
-        <div v-show="data.isActive" class="absolute left-0 top-full pt-0.5 z-50 w-full rounded peer-read-only:hidden">
-            <ul class="overflow-auto divide-y-2 divide-gray-100 rounded-b bg-white shadow-lg z-50 max-h-60">
-                <template v-if="dropdownListItems.length > 0">
-                    <li v-for="(item,index) in dropdownListItems" :key="index" @click.stop="selectItem(item)" :class="liClass(item)" class="py-2 px-3 min-w-full text-gray-700 cursor-pointer hover:bg-gray-100">
-                    <slot name="item" :item="item" :index="index">
-                        {{ typeof item === "object" ? item[itemValue] : item }}
-                    </slot>
-                </li>
-                </template>
-                <li v-if="dropdownListItems.length === 0" @click="data.isActive=false" class="p-2 min-w-full text-xs text-gray-500">
-                    <slot name="empty">
-                        一件もデータがありません
-                    </slot>
-                </li>
-            </ul>
-        </div>
     </div>
     <div v-show="appendIcon" class="my-auto text-lg col-start-3 pt-1.5 pl-1">
         <c-svg-icon :icon="appendIcon" @click="$emit('click:append')" size="medium" class="cursor-pointer" :class="error?'text-[var(--cuv-danger-text)]':'text-gray-500'"/>
@@ -268,4 +319,22 @@ watchEffect(() => {
         </p>
     </div>
 </div>
+<Teleport :to="teleportTarget">
+    <div v-if="data.isActive" @mouseover="optionsMouseOver()" @mouseleave="data.isHover=false" :style="{width:optionsPosition.width, top:optionsPosition.top, left:optionsPosition.left}"  class="absolute pt-0.5 z-50 rounded peer-read-only:hidden">
+        <ul ref="optionsRef" class="overflow-auto divide-y-2 divide-gray-100 rounded-b bg-white shadow-lg z-50 max-h-60">
+            <template v-if="dropdownListItems.length > 0">
+                <li v-for="(item,index) in dropdownListItems" :key="index" @click.stop="selectItem(item)" :class="liClass(item)" class="py-2 px-3 min-w-full text-gray-700 cursor-pointer hover:bg-gray-100">
+                <slot name="item" :item="item" :index="index">
+                    {{ typeof item === "object" ? item[itemValue] : item }}
+                </slot>
+            </li>
+            </template>
+            <li v-if="dropdownListItems.length === 0" @click="data.isActive=false" class="p-2 min-w-full text-xs text-gray-500">
+                <slot name="empty">
+                    一件もデータがありません
+                </slot>
+            </li>
+        </ul>
+    </div>
+</Teleport>
 </template>

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive,  ref,  watchEffect } from 'vue'
+import { getScrollParent } from '@/composables/scroll';
+import { teleportTarget } from '@/composables/teleport'
 import { mdiMenuDown, mdiMenuUp, mdiClose } from '@mdi/js';
 import CSvgIcon from '@/components/images/CSvgIcon.vue';
 
@@ -171,15 +173,6 @@ const selectionSlotDisplay = computed(() => {
     return props.itemValue ? Object.keys(selectionItem).length : selectionItem.value!==''
 })
 
-const teleportTarget = computed(() => {
-    if (typeof window === 'undefined') return undefined
-    const targetElement = document.body
-    const container = document.createElement('div')
-    container.className = 'c-overlay-container'
-    targetElement.appendChild(container)
-    return container
-})
-
 const liClass= (item:any) => {
     if(props.itemValue) return item[props.itemValue]==selectionItem.value[props.itemValue]?'bg-blue-50 text-blue-700':''
     return item == selectionItem.value ? 'bg-blue-50 text-blue-700':''
@@ -229,22 +222,6 @@ const optionClass = () => {
     else optionsPosition.top = fieldEl.value.getBoundingClientRect().top + fieldEl.value.clientHeight + 1 + 'px'
     optionsPosition.left = fieldEl.value.getBoundingClientRect().left+'px'
     optionsPosition.width = fieldEl.value.clientWidth+'px'
-}
-
-const getScrollParent = (el?: HTMLElement) => {
-    while (el) {
-        if (hasScrollbar(el)) return el
-        el = el.parentElement!
-    }
-
-    return document.scrollingElement as HTMLElement
-}
-
-const hasScrollbar = (el?: Element | null) => {
-    if (!el || el.nodeType !== Node.ELEMENT_NODE) return false
-
-    const style = window.getComputedStyle(el)
-    return style.overflowY === 'scroll' || (style.overflowY === 'auto' && el.scrollHeight > el.clientHeight)
 }
 
 watchEffect(() => {

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, reactive,  ref,  watchEffect } from 'vue'
 import { getScrollParent } from '@/composables/scroll';
-import { teleportTarget } from '@/composables/teleport'
 import { mdiMenuDown, mdiMenuUp, mdiClose } from '@mdi/js';
 import CSvgIcon from '@/components/images/CSvgIcon.vue';
 
@@ -296,7 +295,7 @@ watchEffect(() => {
         </p>
     </div>
 </div>
-<Teleport :to="teleportTarget">
+<Teleport to="body">
     <div v-if="data.isActive" @mouseover="optionsMouseOver()" @mouseleave="data.isHover=false" :style="{width:optionsPosition.width, top:optionsPosition.top, left:optionsPosition.left}"  class="absolute pt-0.5 z-50 rounded peer-read-only:hidden">
         <ul ref="optionsRef" class="overflow-auto divide-y-2 divide-gray-100 rounded-b bg-white shadow-lg z-50 max-h-60">
             <template v-if="dropdownListItems.length > 0">

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, reactive, ref, useSlots, watchEffect } from 'vue';
 import { getScrollParent } from '@/composables/scroll';
-import { teleportTarget } from '@/composables/teleport'
 import { mdiMenuDown, mdiMenuUp, mdiClose } from '@mdi/js';
 import CSvgIcon from '@/components/images/CSvgIcon.vue';
 import CCheckbox from '@/components/form/CCheckbox.vue';
@@ -337,7 +336,7 @@ watchEffect(() => {
             {{ msg }}
         </p>
     </div>
-    <Teleport :to="teleportTarget">
+    <Teleport to="body">
         <div v-if="data.isActive" @mouseover="optionsMouseOver()" @mouseleave="data.isHover=false" :style="{width:optionsPosition.width, top:optionsPosition.top, left:optionsPosition.left}" class="absolute pt-0.5 z-50 rounded">
             <ul ref="optionsRef" class="overflow-auto divide-y-2 divide-gray-100 rounded-b bg-white shadow-lg z-50 max-h-60">
                 <template v-if="items.length > 0">

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive, ref, useSlots, watchEffect } from 'vue';
+import { getScrollParent } from '@/composables/scroll';
+import { teleportTarget } from '@/composables/teleport'
 import { mdiMenuDown, mdiMenuUp, mdiClose } from '@mdi/js';
 import CSvgIcon from '@/components/images/CSvgIcon.vue';
 import CCheckbox from '@/components/form/CCheckbox.vue';
@@ -196,15 +198,6 @@ const selectionSlotDisplay = computed(() => {
     return props.items[0][props.itemValue] ? Object.keys(selectionItem.value).length : selectionItem.value.length>0
 })
 
-const teleportTarget = computed(() => {
-    if (typeof window === 'undefined') return undefined
-    const targetElement = document.body
-    const container = document.createElement('div')
-    container.className = 'c-overlay-container'
-    targetElement.appendChild(container)
-    return container
-})
-
 const liClass= (item:any) => {
     if(Array.isArray(props.modelValue)) {
         if(props.multiple && props.items[0][props.itemValue]) return props.modelValue.includes(item[props.itemValue]) ? 'bg-blue-50 text-blue-700':''
@@ -268,22 +261,6 @@ const optionClass = () => {
     else optionsPosition.top = fieldEl.value.getBoundingClientRect().top + fieldEl.value.clientHeight + 1 + 'px'
     optionsPosition.left = fieldEl.value.getBoundingClientRect().left+'px'
     optionsPosition.width = fieldEl.value.clientWidth+'px'
-}
-
-const getScrollParent = (el?: HTMLElement) => {
-    while (el) {
-        if (hasScrollbar(el)) return el
-        el = el.parentElement!
-    }
-
-    return document.scrollingElement as HTMLElement
-}
-
-const hasScrollbar = (el?: Element | null) => {
-    if (!el || el.nodeType !== Node.ELEMENT_NODE) return false
-
-    const style = window.getComputedStyle(el)
-    return style.overflowY === 'scroll' || (style.overflowY === 'auto' && el.scrollHeight > el.clientHeight)
 }
 
 watchEffect(() => {

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -361,7 +361,7 @@ watchEffect(() => {
         </p>
     </div>
     <Teleport :to="teleportTarget">
-        <div @mouseover="optionsMouseOver()" @mouseleave="data.isHover=false" :style="{width:optionsPosition.width, top:optionsPosition.top, left:optionsPosition.left}" :class="data.isActive?'block':'hidden'" class="absolute pt-0.5 z-50 rounded">
+        <div v-if="data.isActive" @mouseover="optionsMouseOver()" @mouseleave="data.isHover=false" :style="{width:optionsPosition.width, top:optionsPosition.top, left:optionsPosition.left}" class="absolute pt-0.5 z-50 rounded">
             <ul ref="optionsRef" class="overflow-auto divide-y-2 divide-gray-100 rounded-b bg-white shadow-lg z-50 max-h-60">
                 <template v-if="items.length > 0">
                     <li v-if="slots.prependItem" class="py-2 px-3 min-w-full text-gray-700 cursor-pointer hover:bg-gray-100">

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -143,18 +143,19 @@ const selectionClass = computed(() => {
     ]
 })
 
-const selectionItem = computed(() => {
+const selectionItem = computed((): any[] => {
+    console.log(typeof props.modelValue)
     if(props.multiple && Array.isArray(props.modelValue)) {
         if(props.items[0][props.itemValue]) return props.items.filter(item => props.modelValue.includes(item[props.itemValue]))
         return props.items.filter(item => props.modelValue.includes(item))
     }
     if(!props.items[0][props.itemValue] && props.modelValue) return props.items.filter(item =>{ return item == props.modelValue})[0]
-    if(!props.items[0][props.itemValue] && !props.modelValue) return ''
+    if(!props.items[0][props.itemValue] && !props.modelValue) return []
     if(props.modelValue) return props.items.filter(item => {
         if(props.items[0][props.itemValue]) return item[props.itemValue] == props.modelValue
     })[0]
 
-    return {}
+    return []
 })
 
 const initSelectionItem = computed(() => {
@@ -178,7 +179,7 @@ const selectionSlotDisplay = computed(() => {
     if (!props.modelValue) return false
     if(!props.items) return false
     if (props.items.length === 0) return false 
-    return props.items[0][props.itemValue] ? Object.keys(selectionItem.value).length : selectionItem.value!==''
+    return props.items[0][props.itemValue] ? Object.keys(selectionItem.value).length : selectionItem.value.length
 })
 
 const liClass= (item:any) => {

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -318,9 +318,11 @@ watchEffect(() => {
                 </span>
             </div>
             <div v-show="selectionSlotDisplay && !Array.isArray(selectionItem)" @click="toggleDropdownList" :class="selectionClass">
-                <slot name="selection" :item="selectionItem" :index="0">
-                    {{ initSelectionItem }}
-                </slot>
+                <template v-for="(item, index) in selectionItem" :key="index">
+                    <slot name="selection" :item="item" :index="0">
+                        {{ initSelectionItem }}
+                    </slot>
+                </template>
             </div>
             <input 
             v-bind="$attrs"

--- a/src/composables/scroll.ts
+++ b/src/composables/scroll.ts
@@ -1,0 +1,15 @@
+export const getScrollParent = (el?: HTMLElement) => {
+    while (el) {
+        if (hasScrollbar(el)) return el
+        el = el.parentElement!
+    }
+
+    return document.scrollingElement as HTMLElement
+}
+
+const hasScrollbar = (el?: Element | null) => {
+    if (!el || el.nodeType !== Node.ELEMENT_NODE) return false
+
+    const style = window.getComputedStyle(el)
+    return style.overflowY === 'scroll' || (style.overflowY === 'auto' && el.scrollHeight > el.clientHeight)
+}

--- a/src/composables/teleport.ts
+++ b/src/composables/teleport.ts
@@ -1,7 +1,0 @@
-import { computed } from "vue"
-
-export const teleportTarget = computed(() => {
-    if (typeof window === 'undefined') return undefined
-    const targetElement = document.body
-    return targetElement
-})

--- a/src/composables/teleport.ts
+++ b/src/composables/teleport.ts
@@ -1,0 +1,10 @@
+import { computed } from "vue"
+
+export const teleportTarget = computed(() => {
+    if (typeof window === 'undefined') return undefined
+    const targetElement = document.body
+    const container = document.createElement('div')
+    container.className = 'c-overlay-container'
+    targetElement.appendChild(container)
+    return container
+})

--- a/src/composables/teleport.ts
+++ b/src/composables/teleport.ts
@@ -3,8 +3,5 @@ import { computed } from "vue"
 export const teleportTarget = computed(() => {
     if (typeof window === 'undefined') return undefined
     const targetElement = document.body
-    const container = document.createElement('div')
-    container.className = 'c-overlay-container'
-    targetElement.appendChild(container)
-    return container
+    return targetElement
 })


### PR DESCRIPTION
#129

上記タイトルのバグを修正しました。
また、optionsがwindowより下に潜ってしまう場合は、fieldの上に表示するように修正しました。
開いた状態でscrollをすると、optionsは閉じる＋Focusが外れるようにしています。

![スクリーンショット 2023-06-13 17 57 47](https://github.com/actier-luchta/cuv/assets/101681088/e831d6e4-05a3-4ab9-afb9-544868aa687b)
![スクリーンショット 2023-06-13 17 58 07](https://github.com/actier-luchta/cuv/assets/101681088/86dc4c02-db25-45ae-ab0a-b228e177f3bc)
