### PR TITLE
Form部品: labelが設定されていないときには上下中央にコンテンツが表示されるようにする

### DIFF
--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -103,9 +103,10 @@ const inputClass = computed(() => {
     return [
         'peer w-full text-gray-900 focus:outline-none focus:ring-0 bg-transparent opacity-100',
         props.modelValue ? 'placeholder:opacity-0' : props.label ? 'placeholder:opacity-0 focus:placeholder:opacity-100' : 'opacity-100',
-        props.variant === 'filled' ? 'pt-4 pb-1' : '',
-        props.variant === 'outlined' ? 'pt-4 pb-1.5' : '',
-        props.variant === 'underlined' ? 'pt-2.5 pb-1' : '',        
+        props.label ? 'pt-4 pb-1' : '',
+        props.variant === 'filled' && !props.label ? 'py-2.5' : '',
+        props.variant === 'outlined' && !props.label ? 'py-2.5' : '',
+        props.variant === 'underlined' && !props.label ? 'pt-4 pb-1' : '',        
     ]
 })
 
@@ -127,7 +128,7 @@ const labelClass = computed(() => {
         ? 'scale-100 translate-y-0' 
         : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
     if(props.variant === 'underlined') base.push(
-        '-translate-y-5 top-3 peer-focus:left-0 peer-focus:-translate-y-5', 
+        '-translate-y-4 top-4 peer-focus:left-0 peer-focus:-translate-y-4', 
         !props.modelValue && !data.inputText
         ? 'scale-100 translate-y-0' 
         : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
@@ -138,6 +139,10 @@ const selectionClass = computed(() => {
     return [
         'pb-1 pt-4 whitespace-nowrap',
         props.readonly || props.disabled ? 'text-gray-500' : 'text-gray-900',
+        props.label ? 'pt-4 pb-1' : '',
+        props.variant === 'filled' && !props.label ? 'py-2.5' : '',
+        props.variant === 'outlined' && !props.label ? 'py-2.5' : '',
+        props.variant === 'underlined' && !props.label ? 'pt-4 pb-1' : '',        
     ]
 })
 
@@ -273,7 +278,6 @@ watchEffect(() => {
             >
                 {{ label }}
             </label>
-
         </div>
         <div v-show="clearIconDisplay" class="pt-2">
             <c-svg-icon :icon="mdiClose" @click="clear" class="text-gray-500 cursor-pointer" />

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -114,9 +114,9 @@ const inputClass = computed(() => {
     if(props.modelValue || Array.isArray(props.modelValue)) base.push('placeholder:opacity-0')
     if(!props.label && (!props.modelValue || !props.modelValue.length)) base.push('placeholder:opacity-100')
     if(props.label && (!props.modelValue || !props.modelValue.length)) base.push('placeholder:opacity-0 focus:placeholder:opacity-100')
-    if(props.variant === 'filled') base.push('pt-4 pb-1')
-    if(props.variant === 'outlined') base.push('pt-4 pb-1.5')
-    if(props.variant === 'underlined') base.push('pt-2.5 pb-1')
+    if(props.variant === 'filled') base.push( props.label ? 'pt-4 pb-1' : 'py-2.5')
+    if(props.variant === 'outlined') base.push(props.label ? 'pt-4 pb-1' : 'py-2.5')
+    if(props.variant === 'underlined') base.push('pt-4 pb-1')
     return base
 })
 
@@ -139,7 +139,7 @@ const labelClass = computed(() => {
         : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-0'
         )
     if(props.variant === 'underlined') base.push(
-        '-translate-y-5 top-3 peer-focus:left-0 peer-focus:-translate-y-5',
+        '-translate-y-4 top-4 peer-focus:left-0 peer-focus:-translate-y-4',
         !props.modelValue || !props.modelValue.length 
         ? 'scale-100 translate-y-0' 
         : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0'
@@ -151,10 +151,11 @@ const labelClass = computed(() => {
 
 const selectionClass = computed(() => {
     return [
-        'pb-1 pr-4 whitespace-nowrap cursor-pointer',
-        props.variant === 'filled' ? 'pt-4' : '',
-        props.variant === 'outlined' ? 'pt-4' : '',
-        props.variant === 'underlined' ? 'pt-2.5' : '',
+        'pr-4 whitespace-nowrap cursor-pointer',
+        props.label ? 'pt-4 pb-1' : '',
+        props.variant === 'filled' && !props.label ? 'py-2.5' : '',
+        props.variant === 'outlined' && !props.label ? 'py-2.5' : '',
+        props.variant === 'underlined' && !props.label ? 'pt-4 pb-1' : '',        
         props.readonly || props.disabled ? 'text-gray-500' : 'text-gray-900',
     ]
 })

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -80,12 +80,12 @@ const inputClass = computed(() => {
         'peer w-full appearance-none text-gray-900 focus:outline-none focus:ring-0 disabled:text-gray-500 read-only:text-gray-500 opacity-100 bg-transparent',
     ]
     if(!props.label) base.push('placeholder:opacity-100')
-    if(props.label && !props.modelValue) base.push('placeholder:opacity-0 focus:placeholder:opacity-100')
-    if(props.label && props.modelValue) base.push('placeholder:opacity-0')
-    if(props.variant === 'filled') base.push('pt-4 pb-1')
-    if(props.variant === 'outlined') base.push('pt-4 pb-1.5')
-    if(props.variant === 'underlined') base.push('pt-2.5 pb-1')
+    if(props.label && !props.modelValue) base.push('pt-4 pb-1 placeholder:opacity-0 focus:placeholder:opacity-100')
+    if(props.label && props.modelValue) base.push('pt-4 pb-1 placeholder:opacity-0')
 
+    if(props.variant === 'filled' && !props.label) base.push('py-2.5')
+    if(props.variant === 'outlined' && !props.label) base.push('py-2.5')
+    if(props.variant === 'underlined' && !props.label) base.push('pt-4 pb-1')
     return base
 })
 
@@ -99,7 +99,7 @@ const labelClass = computed(() => {
     if(props.variant === 'filled' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
     if(props.variant === 'outlined') base.push('-translate-y-4 top-4 left-0 peer-focus:-translate-y-4')
     if(props.variant === 'outlined' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
-    if(props.variant === 'underlined') base.push('-translate-y-5 top-3 left-0 peer-focus:left-0 peer-focus:-translate-y-5')
+    if(props.variant === 'underlined') base.push('-translate-y-4 top-4 left-0 peer-focus:left-0 peer-focus:-translate-y-4')
     if(props.variant === 'underlined' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
     if(!props.modelValue) base.push('scale-100 translate-y-0')
     

--- a/src/components/form/CTextarea.vue
+++ b/src/components/form/CTextarea.vue
@@ -84,9 +84,9 @@ const textareaClass = computed(() => {
     if(!props.label) base.push('placeholder:opacity-100')
     if(props.label && !props.modelValue) base.push('placeholder:opacity-0 focus:placeholder:opacity-100')
     if(props.label && props.modelValue) base.push('placeholder:opacity-0')
-    if(props.variant === 'filled') base.push('min-h-[2.7rem] px-2.5 pb-1 pt-4')
-    if(props.variant === 'outlined') base.push('min-h-[2.8rem] px-2.5 pb-1.5 pt-4')
-    if(props.variant === 'underlined') base.push('min-h-[2.3rem] pt-2.5 pb-1 pl-1')
+    if(props.variant === 'filled') base.push('min-h-[2.7rem] px-2.5 ', props.label ?'pt-4 pb-1':'py-2.5')
+    if(props.variant === 'outlined') base.push('min-h-[2.8rem] px-2.5', props.label ?'pt-4 pb-1':'py-2.5')
+    if(props.variant === 'underlined') base.push('min-h-[2.3rem] pt-4 pb-1 pl-1')
 
     return base
 })
@@ -101,7 +101,7 @@ const labelClass = computed(() => {
     if(props.variant === 'filled' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
     if(props.variant === 'outlined') base.push('-translate-y-4 top-4 px-2 peer-focus:px-2 peer-focus:-translate-y-4 left-1 top-4')
     if(props.variant === 'outlined' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
-    if(props.variant === 'underlined') base.push('-translate-y-4 top-3 pl-1 peer-focus:left-0 peer-focus:-translate-y-4')
+    if(props.variant === 'underlined') base.push('-translate-y-4 top-4 pl-1 peer-focus:left-0 peer-focus:-translate-y-4')
     if(props.variant === 'underlined' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
     if(!props.modelValue) base.push('scale-100 translate-y-0')
     return base
@@ -138,7 +138,7 @@ const clear = () => {
             :placeholder="placeholder"
             :rows="rows"
             :class="textareaClass"/>
-            <label :class="labelClass">
+            <label v-if="label" :class="labelClass">
                 {{ label }}
             </label>
         </div>


### PR DESCRIPTION
#127 

上記タイトルのように、Form部品のlabelが設定されていない時のレイアウトの調整を行いました。

#### 修正したコンポーネント

- Autocomplete
- Select
- Textarea
- Textfield

## Variantが`Filled`の場合
### label有り
<img width="514" alt="スクリーンショット 2023-06-15 9 31 08" src="https://github.com/actier-luchta/cuv/assets/101681088/c0342295-813c-4cae-8c11-5fd4ef7afaaa">

### label無し
<img width="526" alt="スクリーンショット 2023-06-15 9 31 16" src="https://github.com/actier-luchta/cuv/assets/101681088/0000cd87-8583-4fa0-8e84-581c871edd85">

## Variantが`outlined`の場合
### label有り
<img width="526" alt="スクリーンショット 2023-06-15 9 31 31" src="https://github.com/actier-luchta/cuv/assets/101681088/47dac609-b0e6-4fb4-bdb2-2911b64a672d">

### label無し
<img width="515" alt="スクリーンショット 2023-06-15 9 31 39" src="https://github.com/actier-luchta/cuv/assets/101681088/529a9885-242c-4765-8673-8ba94e30b84a">

## Variantが`underlined`の場合
### label有り
<img width="517" alt="スクリーンショット 2023-06-15 9 32 05" src="https://github.com/actier-luchta/cuv/assets/101681088/9fffa2fb-5ab2-4317-8a3a-4cb2d51afb04">

### label無し
<img width="525" alt="スクリーンショット 2023-06-15 9 32 12" src="https://github.com/actier-luchta/cuv/assets/101681088/909ea8f3-b37b-4a42-96f8-8424d8a0aecc">

