### PR TITLE
Autocomplete: 選択したものが長いとフィールドが広がってしまうので修正する

### DIFF
--- a/src/axioms.css
+++ b/src/axioms.css
@@ -1,5 +1,5 @@
 * {
-    max-width: var(--measure);
+    max-width: var(--cuv-measure);
 }
 
 html,

--- a/src/axioms.css
+++ b/src/axioms.css
@@ -1,0 +1,13 @@
+* {
+    max-width: var(--measure);
+}
+
+html,
+body,
+div,
+header,
+nav,
+main,
+footer {
+    max-width: none;
+}

--- a/src/histoire.setup.ts
+++ b/src/histoire.setup.ts
@@ -1,2 +1,3 @@
 import './tailwind.css'
 import './variables.css'
+import './axioms.css'

--- a/src/variables.css
+++ b/src/variables.css
@@ -166,5 +166,5 @@
     --cuv-info-outline-hover: var(--cuv-blue-darken-2);
     --cuv-info-outline-focus: var(--cuv-blue-darken-2);
 
-    --measure: 60em;
+    --cuv-measure: 60em;
 }

--- a/src/variables.css
+++ b/src/variables.css
@@ -165,4 +165,6 @@
     --cuv-info-outline: var(--cuv-blue);
     --cuv-info-outline-hover: var(--cuv-blue-darken-2);
     --cuv-info-outline-focus: var(--cuv-blue-darken-2);
+
+    --measure: 60em;
 }


### PR DESCRIPTION
#125 

グローバルデフォルトのカラム幅を用意することで、広がりすぎを抑えるように修正しました。

