### PR TITLE
CCheckbox: 他の部品と比べてラベルの文字が大きいので修正

### DIFF
--- a/src/components/form/CCheckbox.vue
+++ b/src/components/form/CCheckbox.vue
@@ -76,7 +76,7 @@ const iconColor = computed(() => {
 
 const iconClass = computed(() => {
     return [
-        'group w-10 h-10 rounded-full flex justify-center items-center',
+        'group w-10 h-10 rounded-full flex justify-center items-center text-xl',
         'peer-disabled:text-gray-400 peer-hover:bg-gray-50 peer-focus:bg-gray-50 peer-hover:peer-disabled:bg-transparent',
         iconDisplayStatus.value === 'blank' ? 'text-[var(--cuv-black)]' : iconColor.value,
         props.readonly ? 'peer-read-only:text-gray-500' : '',
@@ -86,7 +86,7 @@ const iconClass = computed(() => {
 
 const labelClass = computed(() => {
     const base = [
-        'text-base peer-disabled:text-gray-400',
+        'peer-disabled:text-gray-400',
     ]
     if(props.readonly) base.push('text-gray-500')
     if(isError.value) base.push('text-[var(--cuv-danger-text)]')
@@ -110,7 +110,7 @@ const indeterminateClick = () => {
 
 <template>
 <div class="relative inline-flex items-center justify-center">
-    <label class="relative text-xl w-auto break-words cursor-pointer inline-flex items-center justify-center">
+    <label class="relative w-auto break-words cursor-pointer inline-flex items-center justify-center">
         <input 
         v-model="checkboxValue" 
         v-bind="$attrs"


### PR DESCRIPTION
#130 

CCheckboxのラベルのフォントサイズを、部品内で指定しないように修正しました。

<img width="497" alt="スクリーンショット 2023-06-16 17 50 31" src="https://github.com/actier-luchta/cuv/assets/101681088/52fc15a0-ae2a-4db0-a571-6de0f361d2ab">
