### PR TITLE
Select：項目を選択すると少しずつ横幅が狭くなる

### DIFF
--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -242,7 +242,7 @@ watchEffect(() => {
     <div v-show="prependIcon" class="text-lg col-start-1 my-auto pt-1.5 pr-1">
         <c-svg-icon :icon="prependIcon" @click="$emit('click:prepend')" size="medium" class="cursor-pointer" :class="error?'text-[var(--cuv-danger-text)]':'text-gray-500'"/>
     </div>
-    <div :class="[fieldClass, $style['c-autocomplete-field']]" ref="fieldEl" :style="{width: `${fieldEl?.clientWidth}px`}">
+    <div :class="[fieldClass, $style['c-autocomplete-field']]" ref="fieldEl" :style="{'min-width': `${fieldEl?.clientWidth}px`}">
         <div v-show="prependInnerIcon" :class="$style['c-autocomplete-field__prepend']" class="my-auto pt-2 pr-2 text-lg">
             <c-svg-icon :icon="prependInnerIcon" @click="$emit('click:prependInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--cuv-danger-text)]':'text-gray-500'"/>
         </div>

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -268,7 +268,7 @@ watchEffect(() => {
     <div v-show="prependIcon" class="my-auto text-lg col-start-1 pt-1.5 pr-1">
         <c-svg-icon :icon="prependIcon" @click="$emit('click:prepend')" size="medium" class="cursor-pointer" :class="error?'text-[var(--cuv-danger-text)]':'text-gray-500'"/>
     </div>
-    <div :class="[fieldClass, $style['c-select-field']]" ref="fieldEl" :style="{width: `${fieldEl?.clientWidth}px`}">
+    <div :class="[fieldClass, $style['c-select-field']]" ref="fieldEl" :style="{'min-width': `${fieldEl?.clientWidth}px`}">
         <div v-show="prependInnerIcon" :class="$style['c-select-field__prepend']" class="my-auto pt-2 pr-2 text-lg">
             <c-svg-icon :icon="prependInnerIcon" @click="$emit('click:prependInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--cuv-danger-text)]':'text-gray-500'"/>
         </div>


### PR DESCRIPTION
#157 

Selectのプルダウンの幅を、selectのフィールドの幅を取得して、指定していたが、
widthで指定したため、幅が狭くなると考えられる。
min-widthに修正して対応しました。

また、Autocompleteも同じく対応しました。

<img width="662" alt="スクリーンショット 2023-06-20 14 01 53" src="https://github.com/actier-luchta/cuv/assets/101681088/3fa57f98-2f50-470f-b68a-efb79465cc9e">
