### PR TITLE
Select：DataTableのperpageを指定するセレクトの幅が小さすぎる

### DIFF
--- a/src/components/dataDisplay/CDataTable.vue
+++ b/src/components/dataDisplay/CDataTable.vue
@@ -322,7 +322,7 @@ watchEffect(() => {
 </template>
 
 <style module>
-.perpage input {
-    width: 0;
+.perpage {
+    max-width: 5rem;
 }
 </style>

--- a/src/components/dataDisplay/CDataTable.vue
+++ b/src/components/dataDisplay/CDataTable.vue
@@ -293,7 +293,7 @@ watchEffect(() => {
             <CCluster justify="flex-end" align="center">
                 <CCluster space="0.2rem" align="center">
                     Items per page:
-                    <CSelect v-model="data.currentPerPage" @update:model-value="changePerPage" :items="perPageArray" variant="outlined" :disabled="!items.length" :class="$style.perpage"/>
+                    <CSelect v-model="data.currentPerPage" @update:model-value="changePerPage" :items="perPageArray" variant="outlined" :disabled="!items.length" class="max-w-[5rem]"/>
                 </CCluster>
                 <div>{{ startRecord }}-{{ endRecord }} of {{ totalItemsLength }}</div>
                 <CCluster>
@@ -320,9 +320,3 @@ watchEffect(() => {
     </COverlay>
 </CTable>
 </template>
-
-<style module>
-.perpage {
-    max-width: 5rem;
-}
-</style>

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -300,7 +300,7 @@ watchEffect(() => {
     <div v-if="data.isActive" @mouseover="optionsMouseOver()" @mouseleave="data.isHover=false" :style="{width:optionsPosition.width, top:optionsPosition.top, left:optionsPosition.left}"  class="absolute pt-0.5 z-50 rounded peer-read-only:hidden">
         <ul ref="optionsRef" class="overflow-auto divide-y-2 divide-gray-100 rounded-b bg-white shadow-lg z-50 max-h-60">
             <template v-if="dropdownListItems.length > 0">
-                <li v-for="(item,index) in dropdownListItems" :key="index" @click.stop="selectItem(item)" :class="liClass(item)" class="py-2 px-3 min-w-full text-gray-700 cursor-pointer whitespace-nowrap truncate hover:bg-gray-100">
+                <li v-for="(item,index) in dropdownListItems" :key="index" @click.stop="selectItem(item)" :class="liClass(item)" class="py-2 px-3 min-w-full text-gray-700 cursor-pointer break-all hover:bg-gray-100">
                     <slot name="item" :item="item" :index="index">
                         {{ typeof item === "object" ? item[itemValue] : item }}
                     </slot>

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -300,11 +300,11 @@ watchEffect(() => {
     <div v-if="data.isActive" @mouseover="optionsMouseOver()" @mouseleave="data.isHover=false" :style="{width:optionsPosition.width, top:optionsPosition.top, left:optionsPosition.left}"  class="absolute pt-0.5 z-50 rounded peer-read-only:hidden">
         <ul ref="optionsRef" class="overflow-auto divide-y-2 divide-gray-100 rounded-b bg-white shadow-lg z-50 max-h-60">
             <template v-if="dropdownListItems.length > 0">
-                <li v-for="(item,index) in dropdownListItems" :key="index" @click.stop="selectItem(item)" :class="liClass(item)" class="py-2 px-3 min-w-full text-gray-700 cursor-pointer hover:bg-gray-100">
-                <slot name="item" :item="item" :index="index">
-                    {{ typeof item === "object" ? item[itemValue] : item }}
-                </slot>
-            </li>
+                <li v-for="(item,index) in dropdownListItems" :key="index" @click.stop="selectItem(item)" :class="liClass(item)" class="py-2 px-3 min-w-full text-gray-700 cursor-pointer whitespace-nowrap truncate hover:bg-gray-100">
+                    <slot name="item" :item="item" :index="index">
+                        {{ typeof item === "object" ? item[itemValue] : item }}
+                    </slot>
+                </li>
             </template>
             <li v-if="dropdownListItems.length === 0" @click="data.isActive=false" class="p-2 min-w-full text-xs text-gray-500">
                 <slot name="empty">

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -335,7 +335,7 @@ watchEffect(() => {
                     <li v-for="(item, index) in items" :key="index" @click="selectItem(item)" :class="liClass(item)" class="py-2 px-3 min-w-full text-gray-700 cursor-pointer hover:bg-gray-100">
                         <c-cluster align="center" space="0">
                             <c-checkbox v-if="multiple" v-model="changeableModelValue" :value="items[0][itemValue]?item[itemValue]:item"/>
-                            <div class="whitespace-nowrap truncate" :class="multiple?'max-w-[calc(100%-40px)]':''">
+                            <div class="break-all" :class="multiple?'max-w-[calc(100%-40px)]':''">
                                 <slot name="item" :item="item" :index="index">
                                     {{ typeof item === "object" ? item[itemValue] : item }}
                                 </slot>

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -335,7 +335,7 @@ watchEffect(() => {
                     <li v-for="(item, index) in items" :key="index" @click="selectItem(item)" :class="liClass(item)" class="py-2 px-3 min-w-full text-gray-700 cursor-pointer hover:bg-gray-100">
                         <c-cluster align="center" space="0">
                             <c-checkbox v-if="multiple" v-model="changeableModelValue" :value="items[0][itemValue]?item[itemValue]:item"/>
-                            <div class="break-all" :class="multiple?'max-w-[calc(100%-40px)]':''">
+                            <div class="whitespace-nowrap truncate" :class="multiple?'max-w-[calc(100%-40px)]':''">
                                 <slot name="item" :item="item" :index="index">
                                     {{ typeof item === "object" ? item[itemValue] : item }}
                                 </slot>


### PR DESCRIPTION
#160 

CDataTableの、Pagination機能の一部である、perPageを指定するセレクトボックスが、狭すぎるので修正しました。

- CDataTableのCSelectに`max-width`を指定
- ドロップダウンの各リストが長いと、３点リーダーで表示する
- ドロップダウンの各リストは改行をしないように修正

<img width="462" alt="スクリーンショット 2023-06-20 15 03 56" src="https://github.com/actier-luchta/cuv/assets/101681088/93dee9fc-d789-49e4-aa02-2cfa88af42b9">
<img width="495" alt="スクリーンショット 2023-06-20 15 04 02" src="https://github.com/actier-luchta/cuv/assets/101681088/e2f2c155-8e86-45b1-a59b-4db85fb64357">
