### PR TITLE
DataTable：tableタグがmax-width:60emになってしまうので修正

### DIFF
--- a/src/axioms.css
+++ b/src/axioms.css
@@ -8,6 +8,7 @@ div,
 header,
 nav,
 main,
+table,
 footer {
     max-width: none;
 }


### PR DESCRIPTION
#161 

`axioms.css`の`max-width: none;`を指定したいタググループに`table`を追加しました。

## 修正前のCDataTable
<img width="1055" alt="スクリーンショット 2023-06-20 15 57 54" src="https://github.com/actier-luchta/cuv/assets/101681088/7ae9bbd5-fb3f-443e-b12a-754a53ce48c6">

## 修正後のCDataTable
<img width="1052" alt="スクリーンショット 2023-06-20 15 58 06" src="https://github.com/actier-luchta/cuv/assets/101681088/bde646b3-67c6-4b86-a549-bc87a78277d1">
