### PR TITLE
DataTable：variant「カスタム」で、セルにchipの表示がされていないので修正

### DIFF
--- a/src/components/dataDisplay/CDataTable.story.vue
+++ b/src/components/dataDisplay/CDataTable.story.vue
@@ -7,6 +7,7 @@ import CSheet from '@/components/containment/CSheet.vue';
 import CCluster from '@/components/layout/CCluster.vue';
 import CTextField from '@/components/form/CTextField.vue';
 import CBox from '@/components/layout/CBox.vue';
+import CChip from '@/components/containment/CChip.vue'
 
 type OptionsType = {
     page: number,
@@ -397,6 +398,15 @@ const desserts = [
     },
 ]
 
+const setGroupColor = (groupName: string) => {
+    if ( groupName == '営業部' ) return 'link'
+    if ( groupName == '採用部' ) return 'danger'
+    if ( groupName == '経営企画部' ) return 'success'
+    if ( groupName == '総務部' ) return 'info'
+    if ( groupName == '人事部' ) return 'primary'
+    return 'dark'    
+}
+
 const FakeAPI = {
     async fetch ({page, itemsPerPage, search}:OptionsType) {
         return new Promise(resolve => {
@@ -416,7 +426,6 @@ const FakeAPI = {
                     resolve({ items: paginated, total: newArray.length })
                     return
                 }
-
                 const paginated = items.slice(start, end)
                 resolve({ items: paginated, total: items.length })
             }, 500)
@@ -481,12 +490,10 @@ onMounted(() => {
         :items="custom.nameList"
         @click:row="logEvent('click:row', $event)"
         >
-            <template v-slot:[`item.gender`]="{item}">
-                <CCluster justify="center">
-                    <CSheet :color="item==='男'?'link':'danger'" rounded="large" class="w-fit">
-                        <p class="text-white px-2">{{ item }}</p>
-                    </CSheet>
-                </CCluster>
+            <template v-slot:[`item.group`]="{item}">
+                <CChip :color="setGroupColor(item)" size="small">
+                    {{ item }}
+                </CChip>
             </template>
         </CDataTable>
     </Variant>


### PR DESCRIPTION
#163 

DataTableページの、カスタムした時の例で、
セルにchipを表示したいサンプルが、データの修正の時に、直し忘れて、バグになっていたので、
その箇所を修正しました。

<img width="865" alt="スクリーンショット 2023-06-21 14 29 58" src="https://github.com/actier-luchta/cuv/assets/101681088/02130e4e-3872-4dd4-906d-6d849f8ef71b">
