### PR TITLE
formコンポーネント全て: readonlyのときはテキストの色を薄くしない

### DIFF
--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -89,8 +89,7 @@ const fieldClass = computed(() => {
         'peer relative grid items-center col-start-2 appearance-none focus:outline-none focus:ring-0 opacity-100',
     ]
     if(isError.value) base.push('border-[var(--cuv-danger-border)] focus-within:border-[var(--cuv-danger-outline-focus)]')
-    if(!isError.value && props.readonly) base.push('focus-within:border-gray-900 border-gray-300') 
-    if(!isError.value && !props.readonly) base.push('focus-within:border-blue-600 border-gray-300')
+    if(!isError.value) base.push('focus-within:border-blue-600 border-gray-300')
 
     if(props.variant === 'filled') base.push('rounded-t-lg rounded-b-none px-2.5 bg-gray-50 border-0 border-b-2')
     if(props.variant === 'outlined') base.push('px-2.5 bg-transparent rounded-lg border')
@@ -120,7 +119,7 @@ const labelClass = computed(() => {
         : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0'
     ]
     if(isError.value) base.push('text-[var(--cuv-danger-text)]')
-    if(!isError.value) base.push('text-gray-500 peer-read-only:peer-focus:text-gray-900 peer-focus:text-blue-600')
+    if(!isError.value) base.push('text-gray-500 peer-focus:text-blue-600')
 
     return base
 })
@@ -128,7 +127,7 @@ const labelClass = computed(() => {
 const selectionClass = computed(() => {
     return [
         'whitespace-nowrap',
-        props.readonly || props.disabled ? 'text-gray-500' : 'text-gray-900',
+        props.disabled ? 'text-gray-500' : 'text-gray-900',
         props.label ? 'pt-4 pb-1' : '',
         props.variant === 'filled' && !props.label ? 'py-2.5' : '',
         props.variant === 'outlined' && !props.label ? 'py-2.5' : '',

--- a/src/components/form/CCheckbox.story.vue
+++ b/src/components/form/CCheckbox.story.vue
@@ -47,17 +47,21 @@ const indeterminate: {
 const disabled: {
     modelValue: boolean
     disabled: boolean
+    color: 'white' | 'black' | 'light' | 'dark' | 'primary' | 'link' | 'success' | 'danger' | 'warning' | 'info'
 } = reactive({
     modelValue: false,
     disabled: true,
+    color: 'black',
 })
 
 const readonly: {
     modelValue: boolean
     readonly: boolean
+    color: 'white' | 'black' | 'light' | 'dark' | 'primary' | 'link' | 'success' | 'danger' | 'warning' | 'info'
 } = reactive({
     modelValue: false,
     readonly: true,
+    color: 'black',
 })
 
 const error: {
@@ -172,9 +176,26 @@ const error: {
         <c-checkbox
             v-model="disabled.modelValue"
             label="disabled"
+            :color="disabled.color"
             :disabled="disabled.disabled"
         />
         <template #controls>
+            <HstSelect
+                v-model="disabled.color"
+                title="color"
+                :options="[
+                            {value: 'white', label: 'white'},
+                            {value: 'black', label: 'black'},
+                            {value: 'light', label: 'light'},
+                            {value: 'dark', label: 'dark'},
+                            {value: 'primary', label: 'primary'},
+                            {value: 'link', label: 'link'},
+                            {value: 'success', label: 'success'},
+                            {value: 'danger', label: 'danger'},
+                            {value: 'warning', label: 'warning'},
+                            {value: 'info', label: 'info'},
+                        ]"
+            />
             <HstCheckbox v-model="disabled.disabled" title="disabled"/>
         </template>
     </Variant>
@@ -182,9 +203,26 @@ const error: {
         <c-checkbox
             v-model="readonly.modelValue"
             label="readonly"
+            :color="readonly.color"
             :readonly="readonly.readonly"
         />
         <template #controls>
+            <HstSelect
+                v-model="readonly.color"
+                title="color"
+                :options="[
+                            {value: 'white', label: 'white'},
+                            {value: 'black', label: 'black'},
+                            {value: 'light', label: 'light'},
+                            {value: 'dark', label: 'dark'},
+                            {value: 'primary', label: 'primary'},
+                            {value: 'link', label: 'link'},
+                            {value: 'success', label: 'success'},
+                            {value: 'danger', label: 'danger'},
+                            {value: 'warning', label: 'warning'},
+                            {value: 'info', label: 'info'},
+                        ]"
+            />
             <HstCheckbox v-model="readonly.readonly" title="readonly"/>
         </template>
     </Variant>

--- a/src/components/form/CCheckbox.vue
+++ b/src/components/form/CCheckbox.vue
@@ -79,7 +79,6 @@ const iconClass = computed(() => {
         'group w-10 h-10 rounded-full flex justify-center items-center text-xl',
         'peer-disabled:text-gray-400 peer-hover:bg-gray-50 peer-focus:bg-gray-50 peer-hover:peer-disabled:bg-transparent',
         iconDisplayStatus.value === 'blank' ? 'text-[var(--cuv-black)]' : iconColor.value,
-        props.readonly ? 'peer-read-only:text-gray-500' : '',
         isError.value ? 'text-[var(--cuv-danger-text)]' : '',
     ]
 })
@@ -88,9 +87,8 @@ const labelClass = computed(() => {
     const base = [
         'peer-disabled:text-gray-400',
     ]
-    if(props.readonly) base.push('text-gray-500')
     if(isError.value) base.push('text-[var(--cuv-danger-text)]')
-    if(!props.readonly && !isError.value) base.push('text-[var(--cuv-black)]')
+    if(!isError.value) base.push('text-[var(--cuv-black)]')
 
     return base
 })

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -129,7 +129,6 @@ const labelClass = computed(() => {
     ]
     if(isError.value ) base.push('text-[var(--cuv-danger-text)]')
     if(!isError.value ) base.push('text-gray-500 peer-focus:text-blue-600')
-    // if(props.readonly) base.push(!props.modelValue || !props.modelValue.length ? 'peer-focus:translate-y-0 peer-focus:!scale-100 peer-focus:text-gray-900' : 'peer-focus:text-gray-900')
 
     return base
 })

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -98,8 +98,7 @@ const fieldClass = computed(() => {
         'peer relative grid col-start-2 items-center w-full appearance-none focus:outline-none focus:ring-0 opacity-100',
     ]
     if(isError.value) base.push('border-[var(--cuv-danger-border)] focus-within:border-[var(--cuv-danger-outline-focus)]')
-    if(!isError.value && props.readonly) base.push('focus-within:border-gray-900 border-gray-300') 
-    if(!isError.value && !props.readonly) base.push('focus-within:border-blue-600 border-gray-300')
+    if(!isError.value) base.push('focus-within:border-blue-600 border-gray-300')
     if(props.variant === 'filled') base.push('min-h-[2.7rem] rounded-t-lg rounded-b-none px-2.5 bg-gray-50 border-0 border-b-2')
     if(props.variant === 'outlined') base.push('min-h-[2.8rem] px-2.5 bg-transparent rounded-lg border')
     if(props.variant === 'underlined') base.push('min-h-[2.3rem] rounded-none px-0 bg-transparent border-0 border-b-2')
@@ -130,7 +129,7 @@ const labelClass = computed(() => {
     ]
     if(isError.value ) base.push('text-[var(--cuv-danger-text)]')
     if(!isError.value ) base.push('text-gray-500 peer-focus:text-blue-600')
-    if(props.readonly) base.push(!props.modelValue || !props.modelValue.length ? 'peer-focus:translate-y-0 peer-focus:!scale-100 peer-focus:text-gray-900' : 'peer-focus:text-gray-900')
+    // if(props.readonly) base.push(!props.modelValue || !props.modelValue.length ? 'peer-focus:translate-y-0 peer-focus:!scale-100 peer-focus:text-gray-900' : 'peer-focus:text-gray-900')
 
     return base
 })
@@ -142,7 +141,7 @@ const selectionClass = computed(() => {
         props.variant === 'filled' && !props.label ? 'py-2.5' : '',
         props.variant === 'outlined' && !props.label ? 'py-2.5' : '',
         props.variant === 'underlined' && !props.label ? 'pt-4 pb-1' : '',        
-        props.readonly || props.disabled ? 'text-gray-500' : 'text-gray-900',
+        props.disabled ? 'text-gray-500' : 'text-gray-900',
     ]
 })
 

--- a/src/components/form/CTextField.story.vue
+++ b/src/components/form/CTextField.story.vue
@@ -84,20 +84,24 @@ const disabled : {
     modelValue: string
     label: string
     variant: 'filled'|'outlined'|'underlined'
+    disabled: boolean
 } = reactive({
     modelValue: '吾輩は猫である',
     label: '夏目漱石',
     variant: 'filled',
+    disabled: true,
 })
 
 const readonly : {
     modelValue: string
     label: string
     variant: 'filled'|'outlined'|'underlined'
+    readonly: boolean
 } = reactive({
     modelValue: 'セロ弾きのゴーシュ',
     label: '宮沢賢治',
     variant: 'filled',
+    readonly: true,
 })
 
 const error : {
@@ -280,10 +284,14 @@ const error : {
                 v-model="disabled.modelValue"
                 :label="disabled.label"
                 :variant="disabled.variant"
-                disabled
+                :disabled="disabled.disabled"
             />
         </c-box>
         <template #controls>
+            <HstCheckbox
+                v-model="disabled.disabled"
+                title="disabled"
+            />
             <HstSelect
             v-model="disabled.variant"
             title="variant"
@@ -302,10 +310,14 @@ const error : {
                 v-model="readonly.modelValue"
                 :label="readonly.label"
                 :variant="readonly.variant"
-                readonly
+                :readonly="readonly.readonly"
             />
         </c-box>
         <template #controls>
+            <HstCheckbox
+                v-model="readonly.readonly"
+                title="readonly"
+            />
             <HstSelect
             v-model="readonly.variant"
             title="variant"

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -66,8 +66,7 @@ const fieldClass = computed(() => {
         'peer w-full col-start-2 flex items-center appearance-none text-gray-900 focus:outline-none focus:ring-0 opacity-100',
     ]
     if(isError.value) base.push('border-[var(--cuv-danger-border)] focus-within:border-[var(--cuv-danger-outline-focus)]')
-    if(!isError.value && props.readonly) base.push('focus-within:border-gray-900 border-gray-300') 
-    if(!isError.value && !props.readonly) base.push('focus-within:border-blue-600 border-gray-300')
+    if(!isError.value) base.push('focus-within:border-blue-600 border-gray-300')
 
     if(props.variant === 'filled') base.push('rounded-t-lg rounded-b-none px-2.5 bg-gray-50 border-0 border-b-2')
     if(props.variant === 'outlined') base.push('px-2.5 bg-transparent rounded-lg border')
@@ -77,7 +76,7 @@ const fieldClass = computed(() => {
 })
 const inputClass = computed(() => {
     const base = [
-        'peer w-full appearance-none text-gray-900 focus:outline-none focus:ring-0 disabled:text-gray-500 read-only:text-gray-500 opacity-100 bg-transparent',
+        'peer w-full appearance-none text-gray-900 focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100 bg-transparent',
     ]
     if(!props.label) base.push('placeholder:opacity-100')
     if(props.label && !props.modelValue) base.push('pt-4 pb-1 placeholder:opacity-0 focus:placeholder:opacity-100')
@@ -94,7 +93,7 @@ const labelClass = computed(() => {
         'absolute text-sm duration-300 transform origin-[0] peer-focus:scale-75 whitespace-nowrap overflow-hidden pointer-events-none',
     ]
     if(isError.value) base.push('text-[var(--cuv-danger-text)]')
-    if(!isError.value) base.push('text-gray-500 peer-read-only:peer-focus:text-gray-900 peer-focus:text-blue-600')
+    if(!isError.value) base.push('text-gray-500 peer-focus:text-blue-600')
     if(props.variant === 'filled') base.push('-translate-y-4 top-4 left-0 peer-focus:-translate-y-4',)
     if(props.variant === 'filled' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
     if(props.variant === 'outlined') base.push('-translate-y-4 top-4 left-0 peer-focus:-translate-y-4')

--- a/src/components/form/CTextarea.vue
+++ b/src/components/form/CTextarea.vue
@@ -68,8 +68,7 @@ const fieldClass = computed(() => {
         'group peer col-start-2 flex items-start w-full',
     ]
     if(isError.value) base.push('border-[var(--cuv-danger-border)] focus-within:border-[var(--cuv-danger-outline-focus)]' )
-    if(!isError.value && props.readonly) base.push('focus-within:border-gray-900')
-    if(!isError.value && !props.readonly) base.push('border-gray-300 focus-within:border-blue-600')
+    if(!isError.value) base.push('border-gray-300 focus-within:border-blue-600')
     if(props.variant === 'filled') base.push('rounded-t-lg rounded-b-none bg-gray-50 border-0 border-b-2')
     if(props.variant === 'outlined') base.push('bg-transparent rounded-lg border')
     if(props.variant === 'underlined') base.push('rounded-none bg-transparent border-0 border-b-2')
@@ -79,7 +78,7 @@ const fieldClass = computed(() => {
 
 const textareaClass = computed(() => {
     const base = [
-        'peer block w-full appearance-none bg-transparent focus:outline-none focus:ring-0 disabled:text-gray-500 read-only:text-gray-500 opacity-100',
+        'peer block w-full appearance-none bg-transparent focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100',
     ]
     if(!props.label) base.push('placeholder:opacity-100')
     if(props.label && !props.modelValue) base.push('placeholder:opacity-0 focus:placeholder:opacity-100')
@@ -96,7 +95,7 @@ const labelClass = computed(() => {
         'absolute text-sm duration-300 transform origin-[0] peer-focus:scale-75 whitespace-nowrap overflow-hidden pointer-events-none',
     ]
     if(isError.value) base.push('text-[var(--cuv-danger-text)]')
-    if(!isError.value) base.push('text-gray-500 peer-read-only:peer-focus:text-gray-900 peer-focus:text-blue-600')
+    if(!isError.value) base.push('text-gray-500 peer-focus:text-blue-600')
     if(props.variant === 'filled') base.push('-translate-y-4 top-4 left-2.5 peer-focus:-translate-y-4')
     if(props.variant === 'filled' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
     if(props.variant === 'outlined') base.push('-translate-y-4 top-4 px-2 peer-focus:px-2 peer-focus:-translate-y-4 left-1 top-4')


### PR DESCRIPTION
#177 

Readonlyの時に、テキストの色やフォーカスした時のborderの色、ラベルの色などが、通常時の色と異なるため、
通常時の色と変えないように(見た目は変わらず、編集だけができない状態)、修正しました。

## 対応したコンポーネント

- Autocomplete
- Checkbox
- Select
- Textarea
- TextField

## Autocompleteの場合(Select、Textarea、TextFieldはほぼ同じ見た目です)

<img width="448" alt="スクリーンショット 2023-06-26 18 02 15" src="https://github.com/actier-luchta/cuv/assets/101681088/413b5637-d57a-4b94-a920-1967a6662df8">

### focusした時
<img width="463" alt="スクリーンショット 2023-06-26 18 02 28" src="https://github.com/actier-luchta/cuv/assets/101681088/1c49fb65-ac99-4c52-a160-12b3c2a1c7c7">

## Checkboxの場合
<img width="146" alt="スクリーンショット 2023-06-27 9 57 21" src="https://github.com/actier-luchta/cuv/assets/101681088/8ecea6e6-bce7-479a-a65d-fd7c6229f066">
