### PR TITLE
CAvatar: Github Pageでimageに渡す画像ファイルが表示されない

### DIFF
--- a/src/components/images/CAvatar.story.vue
+++ b/src/components/images/CAvatar.story.vue
@@ -177,7 +177,7 @@ const icon = computed(() => {
 | variant | 'text' \| 'flat' \| 'elevated' \| 'tonal' \| 'outlined' \| 'plain' | 'flat' | コンポーネントに個別のスタイルを適用します |
 
 #### *1
-画像ファイルをimportしてモジュール名を指定することでコンポーネントに画像を適用します
+バンドラにviteを利用している場合、以下の例のように、画像ファイルをimportしそのモジュール名を指定することで、viteによって解決されたpathを渡すことができます
 refs. https://ja.vitejs.dev/guide/assets.html#importing-asset-as-url
 ```
 <script setup lang="ts">

--- a/src/components/images/CAvatar.story.vue
+++ b/src/components/images/CAvatar.story.vue
@@ -171,10 +171,20 @@ const icon = computed(() => {
 | --- | --- | --- | --- |
 | color | 'white' \| 'black' \| 'light' \| 'dark' \| 'primary' \| 'link' \| 'success' \| 'danger' \| 'warning' \| 'info' | undefined | 色を指定します |
 | icon | string | undefined | iconのpathを指定します |
-| image | string | undefined | 画像のsrcに渡すpathを指定します |
+| image | string | undefined | 画像ファイルをimportしてモジュール名を指定することでコンポーネントに画像を適用します*1 |
 | rounded | 'none' \| 'small' \| 'medium' \| 'large' \| 'x-large' \| 'circle' | 'circle' | コンポーネントの`border-radius`を指定します |
 | size | 'x-small' \| 'small' \| 'medium' \| 'large' \| 'x-large' | "medium" | サイズを指定します |
 | variant | 'text' \| 'flat' \| 'elevated' \| 'tonal' \| 'outlined' \| 'plain' | 'flat' | コンポーネントに個別のスタイルを適用します |
+
+#### *1 imageプロパティを使用するときの例
+```
+<script setup lang="ts">
+import imgUrl from '@/assets/sample_Parakeet.png'
+</script>
+<template>
+    <CAvatar :image="imgUrl"/>
+</template>>
+```
 
 ## Slots
 

--- a/src/components/images/CAvatar.story.vue
+++ b/src/components/images/CAvatar.story.vue
@@ -178,7 +178,7 @@ const icon = computed(() => {
 
 #### *1
 画像ファイルをimportしてモジュール名を指定することでコンポーネントに画像を適用します
-https://ja.vitejs.dev/guide/assets.html#importing-asset-as-url
+refs. https://ja.vitejs.dev/guide/assets.html#importing-asset-as-url
 ```
 <script setup lang="ts">
 import imgUrl from '@/assets/sample.png'

--- a/src/components/images/CAvatar.story.vue
+++ b/src/components/images/CAvatar.story.vue
@@ -171,15 +171,17 @@ const icon = computed(() => {
 | --- | --- | --- | --- |
 | color | 'white' \| 'black' \| 'light' \| 'dark' \| 'primary' \| 'link' \| 'success' \| 'danger' \| 'warning' \| 'info' | undefined | 色を指定します |
 | icon | string | undefined | iconのpathを指定します |
-| image | string | undefined | 画像ファイルをimportしてモジュール名を指定することでコンポーネントに画像を適用します*1 |
+| image | string | undefined | 画像のsrcに渡すpathを指定します*1 |
 | rounded | 'none' \| 'small' \| 'medium' \| 'large' \| 'x-large' \| 'circle' | 'circle' | コンポーネントの`border-radius`を指定します |
 | size | 'x-small' \| 'small' \| 'medium' \| 'large' \| 'x-large' | "medium" | サイズを指定します |
 | variant | 'text' \| 'flat' \| 'elevated' \| 'tonal' \| 'outlined' \| 'plain' | 'flat' | コンポーネントに個別のスタイルを適用します |
 
-#### *1 imageプロパティを使用するときの例
+#### *1
+画像ファイルをimportしてモジュール名を指定することでコンポーネントに画像を適用します
+https://ja.vitejs.dev/guide/assets.html#importing-asset-as-url
 ```
 <script setup lang="ts">
-import imgUrl from '@/assets/sample_Parakeet.png'
+import imgUrl from '@/assets/sample.png'
 </script>
 <template>
     <CAvatar :image="imgUrl"/>

--- a/src/components/images/CAvatar.story.vue
+++ b/src/components/images/CAvatar.story.vue
@@ -6,6 +6,7 @@ import CCluster from "@/components/layout/CCluster.vue";
 import CStack from "@/components/layout/CStack.vue";
 import CSvgIcon from "@/components/images/CSvgIcon.vue";
 import CBox from "@/components/layout/CBox.vue";
+import imgUrl from '@/assets/sample_Parakeet.png'
 
 const data: {
     isIcon: boolean
@@ -24,7 +25,7 @@ const data: {
 })
 
 const image = computed(() => {
-    return data.isImage ? '/cuv/src/assets/sample_Parakeet.png' : undefined
+    return data.isImage ? imgUrl : undefined
 })
 
 const icon = computed(() => {
@@ -139,13 +140,18 @@ const icon = computed(() => {
             </CAvatar>
         </CCluster>
     </Variant>
+    <Variant title="画像" auto-props-disabled>
+        <CCluster justify="center">
+            <CAvatar :image="imgUrl"/>
+        </CCluster>
+    </Variant>
     <Variant title="Slot" auto-props-disabled>
         <CCluster justify="space-around">
             <CAvatar color="primary">
                 <CSvgIcon :icon="mdiAirplane"/>
             </CAvatar>
             <CAvatar color="light">
-                <img src="/cuv/src/assets/sample_cat.png"/>
+                <img src="@/assets/sample_cat.png"/>
             </CAvatar>
             <CAvatar color="warning">
                 CUV


### PR DESCRIPTION
#178 

CAvatarがGithub Pagesで表示できないバグを修正しました。
また、CAvatarのドキュメントも修正しました。

<img width="579" alt="スクリーンショット 2023-06-28 15 20 42" src="https://github.com/actier-luchta/cuv/assets/101681088/8356ff7d-ebae-49ec-945a-0f9740e89411">

## CAvatarのドキュメント
<img width="582" alt="image" src="https://github.com/actier-luchta/cuv/assets/101681088/69b43413-bd39-43e6-b1f8-2751966663c1">