### PR TITLE
Examples/Form/LoginForm: エラーメッセージをCAlertで表示する

### DIFF
--- a/src/examples/form/LoginForm.story.vue
+++ b/src/examples/form/LoginForm.story.vue
@@ -11,6 +11,7 @@ import CCover from "@/components/layout/CCover.vue";
 import CSheet from "@/components/containment/CSheet.vue";
 import COverlay from "@/components/containment/COverlay.vue";
 import CProgress from "@/components/feedback/CProgress.vue";
+import CAlert from "@/components/feedback/CAlert.vue";
 
 const input = reactive({
   email: '',
@@ -104,13 +105,11 @@ const doLogin = async () => {
                     <CCluster justify="center">
                       <img src="https://placehold.jp/100x100.png"/>
                     </CCluster>
-                    <CSheet v-if="failed.length" color="danger">
-                      <CBox padding="small">
-                        <div v-for="(msg, index) of failed" :key="index" class="text-white">
-                          {{ msg }}
-                        </div>
-                      </CBox>
-                    </CSheet>
+                    <CAlert v-if="failed.length" type="error" variant="tonal" density="comfortable">
+                      <div v-for="(msg, index) of failed" :key="index" class="text-sm">
+                        {{ msg }}
+                      </div>
+                    </CAlert>
                     <CTextField type="email"
                                 v-model="input.email"
                                 label="email"


### PR DESCRIPTION
#182 

LoginFormのサンプルページにて、エラーメッセージの表示を、
CAlertコンポーネントの追加前に、CSheetなどを使用して表示していたため、
CAlertに置き換えを行いました。

<img width="540" alt="スクリーンショット 2023-06-28 15 42 25" src="https://github.com/actier-luchta/cuv/assets/101681088/a6a52509-02b9-427a-8169-7d8a59cbfcfa">
