### PR TITLE
CDataTable: FooterのPaginationの右側に余白がないので、クリックが押しづらい

### DIFF
--- a/src/components/dataDisplay/CDataTable.vue
+++ b/src/components/dataDisplay/CDataTable.vue
@@ -290,7 +290,7 @@ watchEffect(() => {
     </slot>
     <template #bottom>
         <slot name="bottom" :page="data.currentPage" :itemsPerPage="data.currentPerPage" :allSelected="data.isAllChecked" :select="data.selectItems" :items="displayItems" :headers="headers">
-            <CCluster justify="flex-end" align="center">
+            <CCluster justify="flex-end" align="center" class="px-4">
                 <CCluster space="0.2rem" align="center">
                     Items per page:
                     <CSelect v-model="data.currentPerPage" @update:model-value="changePerPage" :items="perPageArray" variant="outlined" :disabled="!items.length" class="max-w-[5rem]"/>


### PR DESCRIPTION
#180 

CDataTableのFooterにあるPagination機能の右側に、余白がないため、
画面いっぱいに表示された時に操作しづらい問題があったため、
右側にpaddingで余白を入れました。

<img width="805" alt="スクリーンショット 2023-06-28 16 31 16" src="https://github.com/actier-luchta/cuv/assets/101681088/65a03320-c63b-453a-bf5d-bab5bf09910e">
