### PR TITLE
CTabs: align-tabsプロパティに'title'を追加＋exportする

### DIFF
--- a/src/components/navigation/CTab.vue
+++ b/src/components/navigation/CTab.vue
@@ -25,7 +25,7 @@ const props = withDefaults(defineProps<{
 
 const tabClass = computed(() => {
     return [
-        'border-b border-gray-300 -m-[1px] hover:bg-black/20 focus:bg-black/20 aria-selected:border-b-2',
+        'border-b border-gray-300 -m-[1px] hover:bg-black/20 focus:bg-black/20 aria-selected:border-b-[3px]',
         props.disabled ? '' : 'aria-[selected=false]:!text-current',
         colorClass.value,
     ]

--- a/src/components/navigation/CTabs.story.vue
+++ b/src/components/navigation/CTabs.story.vue
@@ -32,7 +32,7 @@ const number = [
 ]
 
 const data: {
-  alignTabs: 'end' | 'start' | 'center'
+  alignTabs: 'end' | 'start' | 'center' | 'title'
   bgColor: ColorType
   color: ColorType
   density:'default' | 'comfortable' | 'compact'
@@ -113,10 +113,10 @@ const disabled: {
             v-model="data.alignTabs"
             title="alignTabs"
             :options="[
-                        {value: 'title', label: 'title'},
-                        {value: 'end', label: 'end'},
                         {value: 'start', label: 'start'},
                         {value: 'center', label: 'center'},
+                        {value: 'end', label: 'end'},
+                        {value: 'title', label: 'title'},
                     ]"
         />
         <HstSelect
@@ -207,6 +207,7 @@ const disabled: {
     </Variant>
     <Variant title="alignTabs" auto-props-disabled>
       <CBox>
+        <div class="font-semibold text-gray-700 pb-1">start</div>
         <CTabs 
         v-model="alignTabs.modelValue"
         :items="number"
@@ -215,6 +216,7 @@ const disabled: {
         />
       </CBox>
       <CBox>
+        <div class="font-semibold text-gray-700 pb-1">center</div>
         <CTabs 
         v-model="alignTabs.modelValue"
         :items="number"
@@ -223,10 +225,20 @@ const disabled: {
         />
       </CBox>
       <CBox>
+        <div class="font-semibold text-gray-700 pb-1">end</div>
         <CTabs 
         v-model="alignTabs.modelValue"
         :items="number"
         align-tabs="end"
+        bg-color="light"
+        />
+      </CBox>
+      <CBox>
+        <div class="font-semibold text-gray-700 pb-1">title</div>
+        <CTabs 
+        v-model="alignTabs.modelValue"
+        :items="number"
+        align-tabs="title"
         bg-color="light"
         />
       </CBox>
@@ -314,7 +326,7 @@ const disabled: {
 ### CTabs
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| alignTabs | 'end' \| 'start' \| 'center' | 'start' | コンポーネントの位置を指定します |
+| alignTabs | 'end' \| 'start' \| 'center' \| 'title' | 'start' | コンポーネントの位置を指定します |
 | bgColor | colorType* | 'white' | `background-color`を指定します |
 | color | colorType | 'black' | 選択されているタブの`color`を指定します |
 | density | 'default' \| 'comfortable' \| 'compact' | 'default' | コンポーネントが使用する垂直方向の高さを調整します |

--- a/src/components/navigation/CTabs.vue
+++ b/src/components/navigation/CTabs.vue
@@ -17,7 +17,7 @@ type ColorType =
 const $style = useCssModule();
 
 const props = withDefaults(defineProps<{
-    alignTabs?: 'end' | 'start' | 'center'
+    alignTabs?: 'end' | 'start' | 'center' | 'title'
     bgColor?: ColorType
     color?: ColorType
     density?:'default' | 'comfortable' | 'compact'
@@ -72,6 +72,7 @@ const tabsClass = computed(() => {
         useVariant({variant: 'flat', color: props.bgColor}),
         props.alignTabs === 'end' ? $style['c-tabs__align-tabs-end'] : '',
         props.alignTabs === 'center' ? $style['c-tabs__align-tabs-center'] : '',
+        props.alignTabs === 'title' ? $style['c-tabs__align-tabs-title'] : '',
         props.grow ? $style['c-tabs__grow'] : '',
     ]
     return base
@@ -255,6 +256,9 @@ ref="tabs"
 }
 .c-tabs__align-tabs-end *:last-child{
     margin-inline-end: 0;
+}
+.c-tabs__align-tabs-title [role="tab"]:first-child{
+    margin-inline-start: 2.625rem;
 }
 .c-tabs__grow button{
     flex: 1 0 auto;

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,3 +38,6 @@ export {default as CReel} from "./components/layout/CReel.vue"
 export {default as CSidebar} from "./components/layout/CSidebar.vue"
 export {default as CStack} from "./components/layout/CStack.vue"
 export {default as CSwitcher} from "./components/layout/CSwitcher.vue"
+//navigation
+export {default as CTabs} from "./components/navigation/CTabs.vue"
+export {default as CTab} from "./components/navigation/CTab.vue"


### PR DESCRIPTION
#198 

CTabsについて、以下の対応を行いました。

- index.tsでexportをし忘れていたため、CTabsとCTabを追加
- `align-tabs`プロパティに`title`を追加
- storyの修正

<img width="741" alt="スクリーンショット 2023-08-03 13 30 44" src="https://github.com/actier-luchta/cuv/assets/101681088/51c5c193-be51-4d2a-9c85-61887a9f5f04">
