### PR TITLE
CDataTable: item-selectableプロパティを追加する

### DIFF
--- a/src/components/dataDisplay/CDataTable.story.vue
+++ b/src/components/dataDisplay/CDataTable.story.vue
@@ -679,7 +679,7 @@ onMounted(() => {
 | height | string | 'auto' | table全体の高さを指定します |
 | hover | boolean | false | trをhoverした時に背景色をつける際は指定します |
 | items | any[] | [] | 子コンポーネントを自動生成するために使用される文字列またはオブジェクトの配列 |
-| itemSelectable | boolean \| string \| ((item:any) => any) | undefined | 項目を選択可能にするかどうかを制御したい場合、項目のプロパティや関数により指定することができます |
+| itemSelectable | boolean \| string \| ((item:any) => boolean) | undefined | 項目を選択可能にするかどうかを制御したい場合、項目のプロパティや関数により指定することができます |
 | itemsLength | number | undefined | APIから一部の表示データを取得して表示する場合は、総件数を渡します |
 | itemsPerPage | number | 10 | 最初に指定したい表示件数 |
 | itemsPerPageOptions | Array<string/number> | [] | 表示件数の選択肢の配列 |

--- a/src/components/dataDisplay/CDataTable.story.vue
+++ b/src/components/dataDisplay/CDataTable.story.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, reactive } from 'vue';
+import { computed, onMounted, reactive } from 'vue';
 import { logEvent } from 'histoire/client'
 import { mdiMagnify } from '@mdi/js';
 import CDataTable from '@/components/dataDisplay/CDataTable.vue';
@@ -34,192 +34,224 @@ const nameList = [
         name: '田中太郎',
         date: '2021/01/01 10:00',
         group: '営業部',
+        selectable: false,
     },
     {
         id:'002',
         name: '鈴木仁美',
         date: '2021/02/01 12:00',
         group: '総務部',
+        selectable: true,
     },
     {
         id:'003',
         name: '赤坂三郎',
         date: '2021/05/01 10:30',
         group: '人事部',
+        selectable: false,
     },
     {
         id:'004',
         name: '目黒四郎',
         date: '2023/01/01 10:01',
         group: '営業部',
+        selectable: true,
     },
     {
         id:'005',
         name: '池袋五子',
         date: '2021/03/01 11:00',
         group: '総務部',
+        selectable: true,
     },
     {
         id:'006',
         name: '新宿六郎',
         date: '2022/04/01 12:00',
         group: '経営企画部',
+        selectable: false,
     },
     {
         id:'007',
         name: '大崎七子',
         date: '2021/01/01 16:30',
         group: '人事部',
+        selectable: true,
     },
     {
         id:'008',
         name: '神田八子',
         date: '2021/01/01 10:10',
         group: '総務部',
+        selectable: true,
     },
     {
         id:'009',
         name: '池袋九太郎',
         date: '2021/01/01 10:12',
         group: '人事部',
+        selectable: true,
     },
     {
         id:'010',
         name: '大久保十蔵',
         date: '2021/04/01 10:11',
         group: '営業部',
+        selectable: false,
     },
     {
         id:'011',
         name: '田中太郎',
         date: '2023/01/01 10:35',
         group: '経営企画部',
+        selectable: true,
     },
     {
         id:'012',
         name: '鈴木仁美',
         date: '2009/01/01 14:00',
         group: '総務部',
+        selectable: false,
     },
     {
         id:'013',
         name: '赤坂三郎',
         date: '2021/01/01 16:00',
         group: '営業部',
+        selectable: true,
     },
     {
         id:'014',
         name: '目黒四郎',
         date: '2014/01/01 17:00',
         group: '営業部',
+        selectable: true,
     },
     {
         id:'015',
         name: '池袋五子',
         date: '2020/01/01 15:00',
         group: '総務部',
+        selectable: true,
     },
     {
         id:'016',
         name: '新宿六郎',
         date: '2021/04/01 10:34',
         group: '営業部',
+        selectable: true,
     },
     {
         id:'017',
         name: '大崎七子',
         date: '2020/04/01 10:56',
         group: '総務部',
+        selectable: false,
     },
     {
         id:'018',
         name: '神田八子',
         date: '2019/04/01 11:30',
         group: '総務部',
+        selectable: true,
     },
     {
         id:'019',
         name: '池袋九太郎',
         date: '2021/01/01 10:40',
         group: '営業部',
+        selectable: true,
     },
     {
         id:'020',
         name: '大久保十蔵',
         date: '2018/01/01 10:44',
         group: '営業部',
+        selectable: true,
     },
     {
         id:'021',
         name: '田中太郎',
         date: '2018/01/01 10:47',
         group: '営業部',
+        selectable: true,
     },
     {
         id:'022',
         name: '鈴木仁美',
         date: '2017/01/01 10:51',
         group: '採用部',
+        selectable: true,
     },
     {
         id:'023',
         name: '赤坂三郎',
         date: '2023/01/01 10:52',
         group: '営業部',
+        selectable: true,
     },
     {
         id:'024',
         name: '目黒四郎',
         date: '2023/01/01 10:54',
         group: '経営企画部',
+        selectable: true,
     },
     {
         id:'025',
         name: '池袋五子',
         date: '2019/04/01 10:58',
         group: '総務部',
+        selectable: false,
     },
     {
         id:'026',
         name: '新宿六郎',
         date: '2020/01/03 15:03',
         group: '営業部',
+        selectable: true,
     },
     {
         id:'027',
         name: '大崎七子',
         date: '2021/04/01 10:11',
         group: '総務部',
+        selectable: true,
     },
     {
         id:'028',
         name: '神田八子',
         date: '2021/01/01 10:12',
         group: '採用部',
+        selectable: true,
     },
     {
         id:'029',
         name: '池袋九太郎',
         date: '2021/01/03 10:34',
         group: '経営企画部',
+        selectable: true,
     },
     {
         id:'030',
         name: '大久保十蔵',
         date: '2022/01/04 10:00',
         group: '営業部',
+        selectable: false,
     },
     {
         id:'031',
         name: '田中太郎',
         date: '2022/01/05 10:00',
         group: '採用部',
+        selectable: true,
     },
     {
         id:'032',
         name: '鈴木仁美',
         date: '2021/12/01 10:00',
         group: '総務部',
+        selectable: false,
     },
 ]
 
@@ -254,6 +286,18 @@ const checked: {
     nameList: nameList,
     headers: nameListHeaders,
     selectItems: [],
+})
+
+const checkable: {
+    nameList: NameListType[]
+    headers: HeaderType[]
+    selectItems: string[]
+    itemSelectable: string
+} = reactive({
+    nameList: nameList,
+    headers: nameListHeaders,
+    selectItems: [],
+    itemSelectable: 'key'
 })
 
 const search: {
@@ -461,6 +505,11 @@ const filterOnlyCapsText =  (value:string, query: string) => {
         value.toString().toLocaleUpperCase().indexOf(query) !== -1
 }
 
+const itemSelectableValue = computed(() => {
+    if ( checkable.itemSelectable === 'key' ) return 'selectable'
+    return ((item:any) => item.group === '総務部')
+})
+
 onMounted(() => {
     loadItems({page:1, itemsPerPage:severSide.itemsPerPage})
 })
@@ -507,6 +556,34 @@ onMounted(() => {
         show-select
         @click:row="logEvent('click:row', $event)"
         ></CDataTable>
+    </Variant>
+    <Variant title="選択可能な行" auto-props-disabled>
+        <div>選択された行のID： {{ checkable.selectItems }}</div>
+        <CDataTable
+        v-model="checkable.selectItems"
+        :headers="checkable.headers"
+        :items="checkable.nameList"
+        item-value="id"
+        :item-selectable="itemSelectableValue"
+        show-select
+        @click:row="logEvent('click:row', $event)"
+        ></CDataTable>
+        <template #controls>
+            <HstRadio
+                v-model="checkable.itemSelectable"
+                title="item-selectable"
+                :options="[
+                    {
+                    label: 'key指定(selectableがtrueの時)',
+                    value: 'key',
+                    },
+                    {
+                    label: '関数指定(総務部のみ可)',
+                    value: 'function',
+                    },
+                ]"
+                />
+    </template>
     </Variant>
     <Variant title="絞り込み" auto-props-disabled>
         <CDataTable
@@ -602,6 +679,7 @@ onMounted(() => {
 | height | string | 'auto' | table全体の高さを指定します |
 | hover | boolean | false | trをhoverした時に背景色をつける際は指定します |
 | items | any[] | [] | 子コンポーネントを自動生成するために使用される文字列またはオブジェクトの配列 |
+| itemSelectable | string \| ((item:any) => any) | undefined | 項目を選択可能にするかどうかを制御したい場合、項目のプロパティや関数により指定することができます |
 | itemsLength | number | undefined | APIから一部の表示データを取得して表示する場合は、総件数を渡します |
 | itemsPerPage | number | 10 | 最初に指定したい表示件数 |
 | itemsPerPageOptions | Array<string/number> | [] | 表示件数の選択肢の配列 |

--- a/src/components/dataDisplay/CDataTable.story.vue
+++ b/src/components/dataDisplay/CDataTable.story.vue
@@ -300,6 +300,25 @@ const checkable: {
     itemSelectable: 'key'
 })
 
+const checkableFunction: {
+    headers: HeaderType[]
+    selectItems: string[]
+} = reactive({
+    headers: [
+    {
+        title: 'デザート (100g)',
+        key: 'name',
+        align: 'start',
+    },
+    { title: 'カロリー', key: 'calories', align: 'end' },
+    { title: '脂質 (g)', key: 'fat', align: 'end' },
+    { title: '炭水化物 (g)', key: 'carbs', align: 'end' },
+    { title: 'タンパク質 (g)', key: 'protein', align: 'end' },
+    { title: '鉄分 (%)', key: 'iron', align: 'end' },
+    ],
+    selectItems: [],
+})
+
 const search: {
     nameList: NameListType[]
     headers: HeaderType[]
@@ -505,11 +524,6 @@ const filterOnlyCapsText =  (value:string, query: string) => {
         value.toString().toLocaleUpperCase().indexOf(query) !== -1
 }
 
-const itemSelectableValue = computed(() => {
-    if ( checkable.itemSelectable === 'key' ) return 'selectable'
-    return ((item:any) => item.group === '総務部')
-})
-
 onMounted(() => {
     loadItems({page:1, itemsPerPage:severSide.itemsPerPage})
 })
@@ -557,33 +571,29 @@ onMounted(() => {
         @click:row="logEvent('click:row', $event)"
         ></CDataTable>
     </Variant>
-    <Variant title="選択可能な行" auto-props-disabled>
+    <Variant title="選択可能な行(文字列を渡した場合)" auto-props-disabled>
         <div>選択された行のID： {{ checkable.selectItems }}</div>
         <CDataTable
         v-model="checkable.selectItems"
         :headers="checkable.headers"
         :items="checkable.nameList"
         item-value="id"
-        :item-selectable="itemSelectableValue"
+        item-selectable="selectable"
         show-select
         @click:row="logEvent('click:row', $event)"
         ></CDataTable>
-        <template #controls>
-            <HstRadio
-                v-model="checkable.itemSelectable"
-                title="item-selectable"
-                :options="[
-                    {
-                    label: 'key指定(selectableがtrueの時)',
-                    value: 'key',
-                    },
-                    {
-                    label: '関数指定(総務部のみ可)',
-                    value: 'function',
-                    },
-                ]"
-                />
-    </template>
+    </Variant>
+    <Variant title="選択可能な行(関数指定)" auto-props-disabled>
+        <div>選択された行のID： {{ checkableFunction.selectItems }}</div>
+        <CDataTable
+        v-model="checkableFunction.selectItems"
+        :headers="checkableFunction.headers"
+        :items="desserts"
+        item-value="name"
+        :item-selectable="(item:any) => item.calories > 300"
+        show-select
+        @click:row="logEvent('click:row', $event)"
+        ></CDataTable>
     </Variant>
     <Variant title="絞り込み" auto-props-disabled>
         <CDataTable
@@ -679,7 +689,7 @@ onMounted(() => {
 | height | string | 'auto' | table全体の高さを指定します |
 | hover | boolean | false | trをhoverした時に背景色をつける際は指定します |
 | items | any[] | [] | 子コンポーネントを自動生成するために使用される文字列またはオブジェクトの配列 |
-| itemSelectable | boolean \| string \| ((item:any) => boolean) | undefined | 項目を選択可能にするかどうかを制御したい場合、項目のプロパティや関数により指定することができます |
+| itemSelectable | string \| ((item:any) => boolean) | undefined | 項目を選択可能にするかどうかを制御したい場合、項目のプロパティや関数により指定することができます |
 | itemsLength | number | undefined | APIから一部の表示データを取得して表示する場合は、総件数を渡します |
 | itemsPerPage | number | 10 | 最初に指定したい表示件数 |
 | itemsPerPageOptions | Array<string/number> | [] | 表示件数の選択肢の配列 |

--- a/src/components/dataDisplay/CDataTable.story.vue
+++ b/src/components/dataDisplay/CDataTable.story.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, reactive } from 'vue';
+import { onMounted, reactive } from 'vue';
 import { logEvent } from 'histoire/client'
 import { mdiMagnify } from '@mdi/js';
 import CDataTable from '@/components/dataDisplay/CDataTable.vue';

--- a/src/components/dataDisplay/CDataTable.story.vue
+++ b/src/components/dataDisplay/CDataTable.story.vue
@@ -679,7 +679,7 @@ onMounted(() => {
 | height | string | 'auto' | table全体の高さを指定します |
 | hover | boolean | false | trをhoverした時に背景色をつける際は指定します |
 | items | any[] | [] | 子コンポーネントを自動生成するために使用される文字列またはオブジェクトの配列 |
-| itemSelectable | string \| ((item:any) => any) | undefined | 項目を選択可能にするかどうかを制御したい場合、項目のプロパティや関数により指定することができます |
+| itemSelectable | boolean \| string \| ((item:any) => any) | undefined | 項目を選択可能にするかどうかを制御したい場合、項目のプロパティや関数により指定することができます |
 | itemsLength | number | undefined | APIから一部の表示データを取得して表示する場合は、総件数を渡します |
 | itemsPerPage | number | 10 | 最初に指定したい表示件数 |
 | itemsPerPageOptions | Array<string/number> | [] | 表示件数の選択肢の配列 |

--- a/src/components/dataDisplay/CDataTable.vue
+++ b/src/components/dataDisplay/CDataTable.vue
@@ -33,7 +33,7 @@ const props = withDefaults(defineProps<{
     height?: string
     hover?: boolean
     items: any[]
-    itemSelectable?: string | ((item:any) => any)
+    itemSelectable?: boolean | string | ((item:any) => any)
     itemsLength?: number
     itemsPerPage?: number
     itemsPerPageOptions?: Array<string|number>
@@ -234,6 +234,7 @@ const changePerPage = () => {
 
 const isSelectItem = (item: any) => {
     if ( !props.itemSelectable ) return true
+    if ( typeof props.itemSelectable === 'boolean'  ) return props.itemSelectable
     if ( typeof props.itemSelectable === 'string'  ) return item[props.itemSelectable]
     return props.itemSelectable(item)
 }

--- a/src/components/dataDisplay/CDataTable.vue
+++ b/src/components/dataDisplay/CDataTable.vue
@@ -33,7 +33,7 @@ const props = withDefaults(defineProps<{
     height?: string
     hover?: boolean
     items: any[]
-    itemSelectable?: boolean | string | ((item:any) => any)
+    itemSelectable?: boolean | string | ((item:any) => boolean)
     itemsLength?: number
     itemsPerPage?: number
     itemsPerPageOptions?: Array<string|number>

--- a/src/components/dataDisplay/CDataTable.vue
+++ b/src/components/dataDisplay/CDataTable.vue
@@ -33,7 +33,7 @@ const props = withDefaults(defineProps<{
     height?: string
     hover?: boolean
     items: any[]
-    itemSelectable?: boolean | string | ((item:any) => boolean)
+    itemSelectable?: string | ((item:any) => boolean)
     itemsLength?: number
     itemsPerPage?: number
     itemsPerPageOptions?: Array<string|number>

--- a/src/components/dataDisplay/CDataTable.vue
+++ b/src/components/dataDisplay/CDataTable.vue
@@ -33,6 +33,7 @@ const props = withDefaults(defineProps<{
     height?: string
     hover?: boolean
     items: any[]
+    itemSelectable?: string | ((item:any) => any)
     itemsLength?: number
     itemsPerPage?: number
     itemsPerPageOptions?: Array<string|number>
@@ -195,7 +196,7 @@ const headerAlign = (align?: 'start' | 'end') => {
 
 const changeAllSelect = () => {
     data.selectItems = []
-    if(data.isAllChecked) data.selectItems.push(...props.items.map(x => x[props.itemValue]))
+    if(data.isAllChecked) data.selectItems.push(...props.items.filter(item => isSelectItem(item)).map(x => x[props.itemValue]))
     changeCheckbox()
     return
 }
@@ -231,8 +232,15 @@ const changePerPage = () => {
     return
 }
 
+const isSelectItem = (item: any) => {
+    if ( !props.itemSelectable ) return true
+    if ( typeof props.itemSelectable === 'string'  ) return item[props.itemSelectable]
+    return props.itemSelectable(item)
+}
+
 watchEffect(() => {
-    if(data.selectItems.length !== props.items.length) data.isAllChecked = false
+    if(data.selectItems.length !== props.items.filter(item => isSelectItem(item)).length) data.isAllChecked = false
+    if(data.selectItems.length === props.items.filter(item => isSelectItem(item)).length) data.isAllChecked = true
 })
 
 </script>
@@ -266,7 +274,7 @@ watchEffect(() => {
             <slot name="tbody" :page="data.currentPage" :itemsPerPage="data.currentPerPage" :allSelected="data.isAllChecked" :select="data.selectItems" :items="displayItems" :headers="headers">
                 <tr v-for="(item, index) in  displayItems" :key="index">
                     <td v-show="showSelect" class="text-center">
-                        <CCheckbox v-model="data.selectItems" :value="item[itemValue]" @change="changeCheckbox" />
+                        <CCheckbox v-model="data.selectItems" :value="item[itemValue]" @change="changeCheckbox" :disabled="!isSelectItem(item)" />
                     </td>
                     <td v-for="(header, index) in headers" :key="index" @click="emits('click:row', item[itemValue])" :class="headerAlign(header.align)">
                         <slot :name="[`item.${header.key}`]" :item="item[header.key]" :index="index">


### PR DESCRIPTION
#204 

CDataTableコンポーネントに、item-selectableプロパティを追加して、
Histoireに、variantを追加しました。

![スクリーンショット 2023-08-16 15 47 38](https://github.com/actier-luchta/cuv/assets/101681088/f34026bd-cdb9-4d49-bcc5-de136020d84a)
![スクリーンショット 2023-08-16 15 47 57](https://github.com/actier-luchta/cuv/assets/101681088/11d23c60-07fa-4488-9739-8d37b36d7634)


