### PR TITLE
CAutocomplete：読み取り専用のラベルが、値がある場合も下がってしまうので修正

### DIFF
--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -112,12 +112,11 @@ const inputClass = computed(() => {
 
 const labelClass = computed(() => {
     const base = [
-        'absolute left-0 text-sm duration-300 transform origin-[0] peer-focus:scale-75 whitespace-nowrap overflow-hidden pointer-events-none',
-        '-translate-y-4 top-4 peer-focus:-translate-y-4',
-        !props.modelValue && !data.inputText
-        ? 'scale-100 translate-y-0' 
-        : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0'
+        'absolute left-0 text-sm duration-300 transform origin-[0] whitespace-nowrap overflow-hidden pointer-events-none',
+        'peer-focus:scale-75 -translate-y-4 top-4 peer-focus:-translate-y-4',
     ]
+    if (!props.modelValue && !data.inputText) base.push('scale-100 translate-y-0')
+    if (props.modelValue || data.inputText) base.push('scale-75')
     if(isError.value) base.push('text-[var(--cuv-danger-text)]')
     if(!isError.value) base.push('text-gray-500 peer-focus:text-blue-600')
 


### PR DESCRIPTION
#206 

タイトルの通り、修正を行いました。

![スクリーンショット 2023-08-16 13 33 19](https://github.com/actier-luchta/cuv/assets/101681088/fabaed08-3a2f-4f0d-9dca-71de632aae17)
