### PR TITLE
CAutocomplete/CSelect/CTextField：labelがない時に、clearableのアイコンとプルダウンのアイコンを上下センターに寄せる

### DIFF
--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -135,6 +135,22 @@ const selectionClass = computed(() => {
     ]
 })
 
+const clearIconClass = computed(() => {
+    const base = ['pl-2']
+    if ( props.variant === 'filled' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'outlined' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'underlined' ) base.push('pt-3')
+    return base
+})
+
+const menuIconClass = computed(() => {
+    const base = []
+    if ( props.variant === 'filled' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'outlined' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'underlined' ) base.push('pt-3')
+    return base
+})
+
 const dropdownListItems = computed(() => {
     if (!props.items) return []
     if (!data.inputText) return props.items
@@ -275,10 +291,10 @@ watchEffect(() => {
                 </label>
             </div>
         </div>
-        <div v-show="clearIconDisplay" :class="$style['c-autocomplete-field__clear']" class="pt-2">
+        <div v-show="clearIconDisplay" :class="[$style['c-autocomplete-field__clear'], clearIconClass]">
             <c-svg-icon :icon="mdiClose" @click="clear" class="text-gray-500 cursor-pointer" />
         </div>
-        <div v-show="menuIconDisplay" :class="$style['c-autocomplete-field__menu']" class="pt-2">
+        <div v-show="menuIconDisplay" :class="[$style['c-autocomplete-field__menu'], menuIconClass]">
             <c-svg-icon :icon="data.isActive ? mdiMenuUp : mdiMenuDown" @click="toggleDropdownList" :class="isError ? 'text-[var(--cuv-danger-text)]':'text-gray-500'"/>
         </div>
         <div v-show="appendInnerIcon" :class="$style['c-autocomplete-field__append']" class="my-auto pt-2 pl-1 text-lg">

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -144,6 +144,22 @@ const selectionClass = computed(() => {
     ]
 })
 
+const clearIconClass = computed(() => {
+    const base = ['pl-2']
+    if ( props.variant === 'filled' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'outlined' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'underlined' ) base.push('pt-3')
+    return base
+})
+
+const menuIconClass = computed(() => {
+    const base = []
+    if ( props.variant === 'filled' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'outlined' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'underlined' ) base.push('pt-3')
+    return base
+})
+
 const selectionItem = computed((): any[] => {
     if(props.multiple && Array.isArray(props.modelValue)) {
         if(props.items[0][props.itemValue]) return props.items.filter(item => props.modelValue.includes(item[props.itemValue]))
@@ -305,10 +321,10 @@ watchEffect(() => {
                 </label>
             </div>
         </div>
-        <div v-show="clearIconDisplay" :class="$style['c-select-field__clear']" class="pt-2">
+        <div v-show="clearIconDisplay" :class="[$style['c-select-field__clear'], clearIconClass]">
             <c-svg-icon :icon="mdiClose" @click="clear" class="text-gray-500 cursor-pointer" />
         </div>
-        <div v-show="menuIconDisplay" :class="$style['c-select-field__menu']" class="pt-2">
+        <div v-show="menuIconDisplay" :class="[$style['c-select-field__menu'], menuIconClass]">
             <c-svg-icon :icon="data.isActive ? mdiMenuUp : mdiMenuDown" @click="toggleDropdownList" :class="isError ? 'text-[var(--cuv-danger-text)]':'text-gray-500'"/>
         </div>
         <div v-show="appendInnerIcon" :class="$style['c-select-field__append']" class="my-auto pt-2 pl-1 text-lg">

--- a/src/components/form/CTextField.story.vue
+++ b/src/components/form/CTextField.story.vue
@@ -240,6 +240,7 @@ const error : {
                     :variant="icons.variant"
                     :prepend-icon="mdiComment"
                     @click:prepend="logEvent('fire click:prepend', $event)"
+                    clearable
                 />
                 <c-text-field 
                     v-model="icons.modelValue"
@@ -247,6 +248,7 @@ const error : {
                     :variant="icons.variant"
                     :append-icon="mdiComment"
                     @click:append="logEvent('fire click:append', $event)"
+                    clearable
                 />
                 <c-text-field 
                     v-model="icons.modelValue"
@@ -254,6 +256,7 @@ const error : {
                     :variant="icons.variant"
                     :prepend-inner-icon="mdiComment"
                     @click:prepend-inner="logEvent('fire click:prepend-inner', $event)"
+                    clearable
                 />
                 <c-text-field 
                     v-model="icons.modelValue"

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -105,6 +105,14 @@ const labelClass = computed(() => {
     return base
 })
 
+const clearIconClass = computed(() => {
+    const base = ['pl-2']
+    if ( props.variant === 'filled' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'outlined' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'underlined' ) base.push('pt-3')
+    return base
+})
+
 const clearIconDisplay = computed(() => {
     if(!props.clearable) return false
     if(props.readonly) return false
@@ -145,7 +153,7 @@ const clear = () => {
                 {{ label }}
             </label>
         </div>
-        <div v-show="clearIconDisplay" class="pt-2">
+        <div v-show="clearIconDisplay" :class="clearIconClass">
             <c-svg-icon :icon="mdiClose" @click="clear" class="text-gray-500 cursor-pointer" />
         </div>
         <div v-show="appendInnerIcon" class="my-auto pt-2 pl-1 text-lg">


### PR DESCRIPTION
#207

タイトルのように、
フォームコンポーネントで、labelがない時に、clearableのアイコンとmenuアイコンがテキストと水平にするために修正しました。

## 対応コンポーネント
- CAutocomplete
- CSelect
- CTextField

![スクリーンショット 2023-08-16 14 18 40](https://github.com/actier-luchta/cuv/assets/101681088/e20e932d-b31c-4182-9c42-6ba7c17bd0d0)
![スクリーンショット 2023-08-16 14 18 45](https://github.com/actier-luchta/cuv/assets/101681088/c303aff1-66cc-4023-b453-ac7d4a0a6073)
![スクリーンショット 2023-08-16 14 18 52](https://github.com/actier-luchta/cuv/assets/101681088/2b8b0e59-baa7-4dd1-a730-499ebde855d2)
