### PR TITLE
CChip：画像をimportする

### DIFF
--- a/src/components/containment/CChip.story.vue
+++ b/src/components/containment/CChip.story.vue
@@ -7,6 +7,7 @@ import CCluster from "@/components/layout/CCluster.vue";
 import CSvgIcon from "@/components/images/CSvgIcon.vue";
 import CAvatar from "@/components/images/CAvatar.vue";
 import CChip from "@/components/containment/CChip.vue";
+import imgUrl from '@/assets/sample_cat.png'
 
 const data: {
     closable: boolean
@@ -176,7 +177,7 @@ const closable: {
             <CChip>
                 <template #prepend>
                     <CAvatar>
-                        <img src="/cuv/src/assets/sample_cat.png"/>
+                        <img :src="imgUrl"/>
                     </CAvatar>
                 </template>
                 今日の猫ニュース


### PR DESCRIPTION
#208 

github pageで画像が読み込まれていないので、
importして表示されるように修正しました。

![スクリーンショット 2023-08-16 15 05 14](https://github.com/actier-luchta/cuv/assets/101681088/d8f5384b-2e23-4f46-b804-02f41cce0997)
