### PR TITLE
Snackbarコンポーネントを作る

### DIFF
--- a/src/components/feedback/CSnackbar.story.vue
+++ b/src/components/feedback/CSnackbar.story.vue
@@ -1,0 +1,261 @@
+<script setup lang="ts">
+import {reactive} from "vue";
+import CCluster from "@/components/layout/CCluster.vue";
+import CButton from "@/components/containment/CButton.vue";
+import CSnackbar from "@/components/feedback/CSnackbar.vue";
+import CBox from "@/components/layout/CBox.vue"
+import CStack from "@/components/layout/CStack.vue"
+
+type ColorType =
+    'white' | 'black' | 'light' | 'dark' | 
+    'primary' | 'link' |
+    'success' | 'danger' | 'warning' | 'info'
+
+const data: {
+    modelValue: boolean
+    timeout: number
+    color: ColorType
+    disabled: boolean
+    location: 'top' | 'bottom'
+    rounded: 'none' | 'small' | 'medium' | 'large' | 'x-large' | 'circle'
+    variant: 'text' | 'flat' | 'elevated' | 'tonal' | 'outlined' | 'plain'
+    vertical: boolean
+} = reactive({
+    modelValue: false,
+    timeout: 5000,
+    color: 'dark',
+    disabled: false,
+    location: 'bottom',
+    rounded: 'medium',
+    variant: 'elevated',
+    vertical: false,
+})
+
+const timeout: {
+    modelValue: boolean
+    timeout: number
+} = reactive({
+    modelValue: false,
+    timeout: 2000
+})
+
+const contained: {
+    modelValue: boolean
+} = reactive({
+    modelValue: false,
+})
+
+const vertical: {
+    modelValue: boolean
+} = reactive({
+    modelValue: false,
+})
+</script>
+
+<template>
+<Story
+    title="Feedback / CSnackbar"
+    :layout="{ type: 'grid', width: '100%' }"
+>
+    <Variant title="基本" auto-props-disabled>
+        <CBox>
+            <CCluster justify="center" space="">
+                <CButton @click="data.modelValue = true" color="primary">
+                    Snackbarを表示
+                </CButton>
+            </CCluster>
+        </CBox>
+        <CSnackbar 
+        v-model="data.modelValue"
+        :timeout="data.timeout"
+        :color="data.color"
+        :disabled="data.disabled"
+        :location="data.location"
+        :rounded="data.rounded"
+        :variant="data.variant"
+        :vertical="data.vertical"
+        >
+            これは、Snackbarです。
+            <template #actions>
+                <CButton @click="data.modelValue = false" variant="text" color="info">
+                    Close
+                </CButton>
+            </template>
+        </CSnackbar>
+        <template #controls>
+            <HstCheckbox v-model="data.modelValue" title="modelValue"/>
+            <HstNumber v-model="data.timeout" title="timeout"/>
+            <HstSelect
+            v-model="data.color"
+            title="color"
+            :options="[
+                        {value: 'white', label: 'white'},
+                        {value: 'black', label: 'black'},
+                        {value: 'light', label: 'light'},
+                        {value: 'dark', label: 'dark'},
+                        {value: 'primary', label: 'primary'},
+                        {value: 'link', label: 'link'},
+                        {value: 'success', label: 'success'},
+                        {value: 'danger', label: 'danger'},
+                        {value: 'warning', label: 'warning'},
+                        {value: 'info', label: 'info'},
+                    ]"
+            />
+            <HstCheckbox v-model="data.disabled" title="disabled"/>
+            <HstSelect 
+            v-model="data.location" 
+            title="location"
+            :options="['top','bottom']"/>
+            <HstSelect
+            v-model="data.rounded"
+            title="rounded"
+            :options="[
+                        {value: 'none', label: 'none'},
+                        {value: 'small', label: 'small'},
+                        {value: 'medium', label: 'medium'},
+                        {value: 'large', label: 'large'},
+                        {value: 'x-large', label: 'x-large'},
+                        {value: 'circle', label: 'circle'},
+                        ]"
+            />
+            <HstSelect
+                v-model="data.variant"
+                title="variant"
+                :options="[
+                            {value: 'text', label: 'text'},
+                            {value: 'flat', label: 'flat'},
+                            {value: 'elevated', label: 'elevated'},
+                            {value: 'tonal', label: 'tonal'},
+                            {value: 'outlined', label: 'outlined'},
+                            {value: 'plain', label: 'plain'},
+                        ]"
+            />
+            <HstCheckbox v-model="data.vertical" title="vertical"/>
+        </template>
+    </Variant>
+    <Variant title="Timeout" auto-props-disabled>
+        <CBox>
+            <CCluster justify="center">
+                <CButton @click="timeout.modelValue = true">
+                    Snackbarを表示
+                </CButton>
+            </CCluster>
+        </CBox>
+        <CSnackbar 
+        v-model="timeout.modelValue"
+        :timeout="timeout.timeout"
+        >
+            このSnackbarは2秒後に非表示になります
+        </CSnackbar>
+    </Variant>
+    <Variant title="variant" auto-props-disabled>
+        <CBox>
+            <CCluster justify="center">
+                <CStack>
+                    <CSnackbar color="primary" variant="flat" rounded="circle">
+                        <template #activator>
+                            <CButton color="primary" variant="flat" rounded="circle">
+                                Snackbarを表示
+                            </CButton>
+                        </template>
+                        これは、Snackbarです。
+                    </CSnackbar>
+                    <CSnackbar color="link" variant="tonal">
+                        <template #activator>
+                            <CButton color="link" variant="tonal">
+                                Snackbarを表示
+                            </CButton>
+                        </template>
+                        これは、Snackbarです。
+                    </CSnackbar>
+                    <CSnackbar color="success" variant="outlined">
+                        <template #activator>
+                            <CButton color="success" variant="outlined">
+                                Snackbarを表示
+                            </CButton>
+                        </template>
+                        これは、Snackbarです。
+                    </CSnackbar>
+                    <CSnackbar color="danger">
+                        <template #activator>
+                            <CButton color="danger">
+                                Snackbarを表示
+                            </CButton>
+                        </template>
+                        これは、Snackbarです。
+                    </CSnackbar>
+                </CStack>
+            </CCluster>
+        </CBox>
+    </Variant>
+    <Variant title="contained" auto-props-disabled>
+        <CBox>
+            <CCluster justify="center">
+                <div class="relative p-4 h-60 max-w-[600px] w-full shadow-lg border border-black rounded">
+                    <CCluster justify="center">
+                        <CButton @click="contained.modelValue = true">
+                            Snackbarを表示
+                        </CButton>
+                    </CCluster>
+                    <CSnackbar v-model="contained.modelValue" contained>
+                        これは、Snackbarです。
+                        <template #actions>
+                            <CButton @click="contained.modelValue = false" color="danger" variant="text">閉じる</CButton>
+                        </template>
+                    </CSnackbar>
+                </div>
+            </CCluster>
+        </CBox>
+    </Variant>
+    <Variant title="variant" auto-props-disabled>
+        <CBox>
+            <CCluster justify="center">
+                <CButton @click="vertical.modelValue = true">
+                    Snackbarを表示
+                </CButton>
+                <CSnackbar v-model="vertical.modelValue" vertical>
+                    これは、Snackbarです。<br/>
+                    コンテンツを重ねて表示することができます。
+                    <template #actions>
+                        <CButton @click="vertical.modelValue = false" color="danger" variant="text">閉じる</CButton>
+                    </template>
+                </CSnackbar>
+            </CCluster>
+        </CBox>
+    </Variant>
+</Story>
+</template>
+
+<docs lang="md">
+# CSnackbar
+ディスプレイの下方または上方から一時的に情報をポップアップ表示することが可能なコンポーネントです。
+
+## Props
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| color | 'white' \| 'black' \| 'light' \| 'dark' \| 'primary' \| 'link' \| 'success' \| 'danger' \| 'warning' \| 'info' | 'black' | コンポーネントの色を指定します |
+| contained | boolean | false | 表示領域を親要素に制限します。(注: 親要素には、position:relative が必要です) |
+| disabled | boolean | false | 非活性にする場合は指定します |
+| id | string | undefined | idを指定します |
+| location | 'top' \| 'bottom' | 'bottom' | ディスプレイに対してコンテンツを表示する位置を指定します |
+| modelValue | boolean | false | コンポーネントのv-model値です。表示する場合はtrueを指定します |
+| rounded | 'none' \| 'small' \| 'medium' \| 'large' \| 'x-large' \| 'circle' | 'circle' | コンポーネントの`border-radius`を指定します |
+| timeout | number | 5000 | 自動的に非表示になるまでの待機時間 (ミリ秒)。常に表示する場合は`-1`を指定します |
+| variant | 'text' \| 'flat' \| 'elevated' \| 'tonal' \| 'outlined' \| 'plain' | 'tonal' | コンポーネントに個別のスタイルを適用します |
+| vertical | boolean | false | コンテンツやアクションボタンを重ねて表示する場合は指定します |
+
+## Slots
+
+| Name | Props (if scoped) | Description |
+| --- | --- | --- |
+| default | - | snackbar内に表示するコンテンツを指定します |
+| activator | - | snackbarをアウティブにするためのコンテンツを指定します |
+| actions | - | snackbar内にアクションボタンを配置する場合に指定します |
+
+## Events
+
+| Name | Parameters | Description |
+| --- | --- | --- |
+| update:modelValue | - | コンポーネントのv-modelが変更されたときに発行されるイベントです |
+</docs>

--- a/src/components/feedback/CSnackbar.vue
+++ b/src/components/feedback/CSnackbar.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import { computed, reactive, useSlots, watchEffect } from 'vue';
+import { useVariant } from '@/composables/variant';
+
+type ColorType =
+    'white' | 'black' | 'light' | 'dark' | 
+    'primary' | 'link' |
+    'success' | 'danger' | 'warning' | 'info'
+
+const slots = useSlots()
+
+const props = withDefaults(defineProps<{
+    color?: ColorType
+    contained?: boolean
+    disabled?: boolean
+    id?: string
+    location?: 'top' | 'bottom'
+    modelValue?: boolean
+    rounded?: 'none' | 'small' | 'medium' | 'large' | 'x-large' | 'circle'
+    timeout?: number
+    variant?: 'text' | 'flat' | 'elevated' | 'tonal' | 'outlined' | 'plain'
+    vertical?: boolean
+}>(), {
+    color:'dark',
+    contained: false,
+    disabled: false,
+    location: 'bottom',
+    modelValue: false,
+    rounded: 'medium',
+    timeout: 5000,
+    variant: 'elevated',
+    vertical: false,
+})
+
+const emits = defineEmits<{
+    (e: 'update:modelValue', value: boolean): void
+}>()
+
+const data: {
+    modelValue: boolean
+} = reactive({
+    modelValue: false,
+})
+
+const isActive = computed({
+    get: () => props.modelValue || data.modelValue,
+    set: value => {
+        emits('update:modelValue', value)
+        data.modelValue = value
+    }
+})
+
+const computedClass = computed(()=> {
+    const base = [
+        "inline-block flex items-center w-auto my-2 opacity-90",
+        "absolute left-1/2 -translate-x-1/2 duration-500",
+        useVariant({variant: props.variant, color: props.color, hover: false, focus: false}),
+        fixedRounded.value,
+        getPosition.value,
+    ]
+    if (props.vertical) base.push('flex-col')
+    return base
+})
+
+const fixedRounded = computed(() => {
+    if ( props.rounded === 'small' ) return 'rounded-sm'
+    if ( props.rounded === 'medium' ) return 'rounded'
+    if ( props.rounded === 'large' ) return 'rounded-lg'
+    if ( props.rounded === 'x-large' ) return 'rounded-3xl'
+    if ( props.rounded === 'circle' ) return 'rounded-full'
+    return 'rounded-none'
+})
+
+const getPosition = computed(() => {
+    if ( props.location === 'top' ) return 'top-0'
+    return 'bottom-0'
+})
+
+const open = () => {
+    if (props.disabled) return
+    data.modelValue = true
+}
+
+watchEffect(() => {
+    if (isActive.value && props.timeout !== -1) {
+        setTimeout(() => {
+            isActive.value = false
+        }, props.timeout)
+    }
+})
+
+</script>
+<template>
+<div
+@click="open"
+>
+    <slot name="activator" :isActive="isActive"/>
+</div>
+<Teleport to="body" :disabled="contained">
+    <Transition>
+        <div 
+        :id="id"
+        v-show="isActive"
+        :class="computedClass" 
+        >
+            <div v-if="slots.default" class="py-3.5 px-4 text-sm">
+                <slot/>
+            </div>
+            <div v-if="slots.actions" :class="vertical?'self-end pb-2':'self-center py-2'" class="px-2">
+                <slot name="actions"/>
+            </div>
+        </div>
+    </Transition>
+</Teleport>
+</template>
+<style>
+.v-enter-active,
+.v-leave-active {
+    transition: opacity 0.3s ease;
+}
+.v-enter-from,
+.v-leave-to {
+    opacity: 0;
+}
+</style>


### PR DESCRIPTION
#190 

Snackbarコンポーネントを作成しました。

<img width="911" alt="スクリーンショット 2023-08-30 14 18 40" src="https://github.com/actier-luchta/cuv/assets/101681088/bd99dd86-709c-443f-9e18-1c5e7cfb29bd">

## デフォルトのsnackbar
<img width="221" alt="スクリーンショット 2023-08-30 14 22 13" src="https://github.com/actier-luchta/cuv/assets/101681088/5b0b4832-94c6-40a0-8244-adbec43d73b5">

## containedプロパティ
<img width="465" alt="スクリーンショット 2023-08-30 14 20 11" src="https://github.com/actier-luchta/cuv/assets/101681088/b8aa8815-8f66-4031-aef2-281f37604e40">

## verticalプロパティ
<img width="169" alt="スクリーンショット 2023-08-30 14 20 27" src="https://github.com/actier-luchta/cuv/assets/101681088/55db19cb-5e49-4d4f-8cfc-d49f1e7c015c">
