### PR TITLE
ラベルをslotで渡せるようにする#220

### DIFF
--- a/src/components/form/CAutocomplete.story.vue
+++ b/src/components/form/CAutocomplete.story.vue
@@ -78,6 +78,14 @@ const clearable: {
     variant: 'filled'
 })
 
+const labelslot: {
+    modelValue: string
+    variant: 'filled'|'outlined'|'underlined'
+} = reactive({
+    modelValue: '1',
+    variant: 'filled'
+})
+
 const icons: {
     modelValue: string
     label: string
@@ -240,6 +248,39 @@ const objectArrayFilter = (item:nameListType, searchText:string) => {
             />
             <HstSelect
             v-model="clearable.variant"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
+        </template>
+    </Variant>
+    <Variant title="Label Slots" auto-props-disabled>
+        <c-box padding="large">
+            <c-autocomplete
+            v-model="labelslot.modelValue"
+            :items="object.nameList"
+            item-value="id"
+            :filter="objectArrayFilter"
+            :variant="labelslot.variant"
+            placeholder="入力"
+            >
+                <template v-slot:selection="{item}">
+                    {{ item.姓 }} {{ item.名 }}
+                </template>
+                <template v-slot:item="{item}">
+                    {{ item.姓 }} {{ item.名 }}
+                </template>
+                <template #label>
+                    氏名<span class="text-red-500">(必須)</span>
+                </template>
+            </c-autocomplete>
+        </c-box>
+        <template #controls>
+            <HstSelect
+            v-model="labelslot.variant"
             title="variant"
             :options="[
                 {value: 'filled', label: 'filled'},

--- a/src/components/form/CAutocomplete.story.vue
+++ b/src/components/form/CAutocomplete.story.vue
@@ -500,6 +500,7 @@ const objectArrayFilter = (item:nameListType, searchText:string) => {
 | empty |  | ドロップダウンリストに一件も表示されない時に使用します |
 | item | item/index | ドロップダウンリストの各項目の表示方法をカスタムできます |
 | selection | item | 選択された値の表示方法をカスタムできます |
+| label | - | ラベルの表示方法をカスタムします |
 
 ## Events
 

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { computed, reactive,  ref,  watchEffect } from 'vue'
+import { computed, reactive,  ref,  useSlots,  watchEffect } from 'vue'
 import { getScrollParent } from '@/composables/scroll';
 import { mdiMenuDown, mdiMenuUp, mdiClose } from '@mdi/js';
 import CSvgIcon from '@/components/images/CSvgIcon.vue';
+
+const slots = useSlots()
 
 const props = withDefaults(defineProps<{
     modelValue: any
@@ -101,11 +103,11 @@ const fieldClass = computed(() => {
 const inputClass = computed(() => {
     return [
         'peer text-gray-900 focus:outline-none focus:ring-0 bg-transparent opacity-100',
-        props.modelValue ? 'placeholder:opacity-0' : props.label ? 'placeholder:opacity-0 focus:placeholder:opacity-100' : 'opacity-100',
-        props.label ? 'pt-4 pb-1' : '',
-        props.variant === 'filled' && !props.label ? 'py-2.5' : '',
-        props.variant === 'outlined' && !props.label ? 'py-2.5' : '',
-        props.variant === 'underlined' && !props.label ? 'pt-4 pb-1' : '',   
+        props.modelValue ? 'placeholder:opacity-0' : props.label || slots.label ? 'placeholder:opacity-0 focus:placeholder:opacity-100' : 'opacity-100',
+        props.label || slots.label ? 'pt-4 pb-1' : '',
+        props.variant === 'filled' && !props.label && !slots.label ? 'py-2.5' : '',
+        props.variant === 'outlined' && !props.label && !slots.label  ? 'py-2.5' : '',
+        props.variant === 'underlined' && !props.label && !slots.label ? 'pt-4 pb-1' : '',   
         !data.inputText.length && props.modelValue ? 'w-4' : 'w-full',
     ]
 })
@@ -136,25 +138,25 @@ const selectionClass = computed(() => {
     return [
         'whitespace-nowrap',
         props.disabled ? 'text-gray-500' : 'text-gray-900',
-        props.label ? 'pt-4 pb-1' : '',
-        props.variant === 'filled' && !props.label ? 'py-2.5' : '',
-        props.variant === 'outlined' && !props.label ? 'py-2.5' : '',
-        props.variant === 'underlined' && !props.label ? 'pt-4 pb-1' : '',        
+        props.label || slots.label ? 'pt-4 pb-1' : '',
+        props.variant === 'filled' && !props.label && !slots.label ? 'py-2.5' : '',
+        props.variant === 'outlined' && !props.label && !slots.label ? 'py-2.5' : '',
+        props.variant === 'underlined' && !props.label && !slots.label ? 'pt-4 pb-1' : '',        
     ]
 })
 
 const clearIconClass = computed(() => {
     const base = ['pl-2']
-    if ( props.variant === 'filled' ) base.push(props.label ? 'pt-2' : '')
-    if ( props.variant === 'outlined' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'filled' ) base.push(props.label || slots.label ? 'pt-2' : '')
+    if ( props.variant === 'outlined' ) base.push(props.label || slots.label ? 'pt-2' : '')
     if ( props.variant === 'underlined' ) base.push('pt-3')
     return base
 })
 
 const menuIconClass = computed(() => {
     const base = []
-    if ( props.variant === 'filled' ) base.push(props.label ? 'pt-2' : '')
-    if ( props.variant === 'outlined' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'filled' ) base.push(props.label || slots.label ? 'pt-2' : '')
+    if ( props.variant === 'outlined' ) base.push(props.label || slots.label ? 'pt-2' : '')
     if ( props.variant === 'underlined' ) base.push('pt-3')
     return base
 })
@@ -295,7 +297,9 @@ watchEffect(() => {
                 <label
                     :class="labelClass"
                     >
-                    {{ label }}
+                    <slot name="label">
+                        {{ label }}
+                    </slot>
                 </label>
             </div>
         </div>

--- a/src/components/form/CDatepicker.story.vue
+++ b/src/components/form/CDatepicker.story.vue
@@ -423,6 +423,7 @@ const format = (date: Date) => {
 | Name | Props (if scoped) | Description |
 | --- | --- | --- |
 | input | - | 日付等を表示するinput部分の表示方法を変更できます |
+| label | - | ラベルの表示方法をカスタムします |
 
 ## Events
 

--- a/src/components/form/CDatepicker.vue
+++ b/src/components/form/CDatepicker.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue'
+import { computed, reactive, ref, useSlots } from 'vue'
 import { mdiCalendar, mdiClose } from '@mdi/js';
 import { ja } from 'date-fns/locale';
 import VueDatePicker from '@vuepic/vue-datepicker';
@@ -7,6 +7,8 @@ import '@vuepic/vue-datepicker/dist/main.css'
 import type { DatePickerInstance } from "@vuepic/vue-datepicker"
 import CSvgIcon from '@/components/images/CSvgIcon.vue';
 import CChip from "@/components/containment/CChip.vue";
+
+const slots = useSlots()
 
 const props = withDefaults(defineProps<{
     appendIcon?: string
@@ -122,9 +124,9 @@ const fieldClass = computed(() => {
 const inputContainerClass = computed(() => {
     return [
         'flex flex-nowrap',
-        props.variant === 'filled' && !props.label ? 'py-2.5' : '',
-        props.variant === 'outlined' && !props.label ? 'py-2.5' : '',
-        props.variant === 'underlined' && !props.label ? 'pt-4 pb-1' : '',   
+        props.variant === 'filled' && !props.label && !slots.label ? 'py-2.5' : '',
+        props.variant === 'outlined' && !props.label && !slots.label ? 'py-2.5' : '',
+        props.variant === 'underlined' && !props.label && !slots.label ? 'pt-4 pb-1' : '',   
     ]
 })
 
@@ -132,8 +134,8 @@ const inputClass = computed(() => {
     return [
         'peer text-gray-900 focus:outline-none focus:ring-0 bg-transparent opacity-100 disabled:text-gray-500 w-full',
         'flex flex-nowrap',
-        props.modelValue ? 'placeholder:opacity-0' : props.label ? 'placeholder:opacity-0 focus:placeholder:opacity-100' : 'opacity-100',
-        props.label ? 'pt-4 pb-1' : '',
+        props.modelValue ? 'placeholder:opacity-0' : props.label || slots.label ? 'placeholder:opacity-0 focus:placeholder:opacity-100' : 'opacity-100',
+        props.label || slots.label ? 'pt-4 pb-1' : '',
         dateValue.value !== '' && props.modelValue ? 'w-4' : 'w-full',
     ]
 })
@@ -163,8 +165,8 @@ const iconClass = computed(() => {
 
 const clearIconClass = computed(() => {
     const base = ['pl-2']
-    if ( props.variant === 'filled' ) base.push(props.label ? 'pt-2' : '')
-    if ( props.variant === 'outlined' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'filled' ) base.push(props.label || slots.label ? 'pt-2' : '')
+    if ( props.variant === 'outlined' ) base.push(props.label || slots.label ? 'pt-2' : '')
     if ( props.variant === 'underlined' ) base.push('pt-3')
     return base
 })
@@ -307,7 +309,9 @@ const clickPrependInnerIcon = () => {
                 <label
                     :class="labelClass"
                     >
-                    {{ label }}
+                    <slot name="label">
+                        {{ label }}
+                    </slot>
                 </label>
             </div>
         </div>

--- a/src/components/form/CSelect.story.vue
+++ b/src/components/form/CSelect.story.vue
@@ -525,6 +525,7 @@ const customToggle = () => {
 | item | item/index| ドロップダウンリストの各項目の表示方法をカスタムできます |
 | prependItem |  | ドロップダウンリストの先頭に追加する表示項目を指定します |
 | selection | item / index| 選択された値の表示方法をカスタムできます |
+| label | - | ラベルの表示方法をカスタムします |
 
 ## Events
 

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -111,10 +111,10 @@ const inputClass = computed(() => {
         'peer w-full focus:outline-none bg-transparent cursor-pointer',
     ]
     if(props.modelValue || Array.isArray(props.modelValue)) base.push('placeholder:opacity-0')
-    if(!props.label && (!props.modelValue || !props.modelValue.length)) base.push('placeholder:opacity-100')
-    if(props.label && (!props.modelValue || !props.modelValue.length)) base.push('placeholder:opacity-0 focus:placeholder:opacity-100')
-    if(props.variant === 'filled') base.push( props.label ? 'pt-4 pb-1' : 'py-2.5')
-    if(props.variant === 'outlined') base.push(props.label ? 'pt-4 pb-1' : 'py-2.5')
+    if(!props.label && !slots.label && (!props.modelValue || !props.modelValue.length)) base.push('placeholder:opacity-100')
+    if((props.label || slots.label) && (!props.modelValue || !props.modelValue.length)) base.push('placeholder:opacity-0 focus:placeholder:opacity-100')
+    if(props.variant === 'filled') base.push(props.label || slots.label ? 'pt-4 pb-1' : 'py-2.5')
+    if(props.variant === 'outlined') base.push(props.label || slots.label ? 'pt-4 pb-1' : 'py-2.5')
     if(props.variant === 'underlined') base.push('pt-4 pb-1')
     return base
 })
@@ -137,10 +137,10 @@ const labelClass = computed(() => {
 const selectionClass = computed(() => {
     return [
         'whitespace-nowrap',
-        props.label ? 'pt-4 pb-1' : '',
-        props.variant === 'filled' && !props.label ? 'py-2.5' : '',
-        props.variant === 'outlined' && !props.label ? 'py-2.5' : '',
-        props.variant === 'underlined' && !props.label ? 'pt-4 pb-1' : '',        
+        props.label || slots.label ? 'pt-4 pb-1' : '',
+        props.variant === 'filled' && !props.label && !slots.label ? 'py-2.5' : '',
+        props.variant === 'outlined' && !props.label && !slots.label ? 'py-2.5' : '',
+        props.variant === 'underlined' && !props.label && !slots.label ? 'pt-4 pb-1' : '',        
         props.disabled ? 'text-gray-500' : 'text-gray-900',
     ]
 })
@@ -155,16 +155,16 @@ const iconClass = computed(() => {
 
 const clearIconClass = computed(() => {
     const base = ['pl-2']
-    if ( props.variant === 'filled' ) base.push(props.label ? 'pt-2' : '')
-    if ( props.variant === 'outlined' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'filled' ) base.push(props.label || slots.label ? 'pt-2' : '')
+    if ( props.variant === 'outlined' ) base.push(props.label || slots.label ? 'pt-2' : '')
     if ( props.variant === 'underlined' ) base.push('pt-3')
     return base
 })
 
 const menuIconClass = computed(() => {
     const base = []
-    if ( props.variant === 'filled' ) base.push(props.label ? 'pt-2' : '')
-    if ( props.variant === 'outlined' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'filled' ) base.push(props.label || slots.label ? 'pt-2' : '')
+    if ( props.variant === 'outlined' ) base.push(props.label || slots.label ? 'pt-2' : '')
     if ( props.variant === 'underlined' ) base.push('pt-3')
     return base
 })
@@ -326,7 +326,9 @@ watchEffect(() => {
                 <label 
                     :class="labelClass"
                 >
-                    {{ label }}
+                    <slot name="label">
+                        {{ label }}
+                    </slot>
                 </label>
             </div>
         </div>

--- a/src/components/form/CTextField.story.vue
+++ b/src/components/form/CTextField.story.vue
@@ -396,7 +396,7 @@ const error : {
 
 | Name | Props (if scoped) | Description |
 | --- | --- | --- |
-| - | - | このコンポーネント独自のSlotはありません |
+| label | - | ラベルの表示方法をカスタムします |
 
 ## Events
 

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import {computed} from 'vue';
+import {computed, useSlots} from 'vue';
 import { mdiClose } from '@mdi/js';
 import CSvgIcon from '@/components/images/CSvgIcon.vue';
+
+const slots = useSlots()
 
 const props = withDefaults(defineProps<{
     modelValue: string
@@ -78,13 +80,13 @@ const inputClass = computed(() => {
     const base = [
         'peer w-full appearance-none text-gray-900 focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100 bg-transparent',
     ]
-    if(!props.label) base.push('placeholder:opacity-100')
-    if(props.label && !props.modelValue) base.push('pt-4 pb-1 placeholder:opacity-0 focus:placeholder:opacity-100')
-    if(props.label && props.modelValue) base.push('pt-4 pb-1 placeholder:opacity-0')
+    if(!props.label && !slots.label) base.push('placeholder:opacity-100')
+    if((props.label || slots.label) && !props.modelValue) base.push('pt-4 pb-1 placeholder:opacity-0 focus:placeholder:opacity-100')
+    if((props.label || slots.label) && props.modelValue) base.push('pt-4 pb-1 placeholder:opacity-0')
 
-    if(props.variant === 'filled' && !props.label) base.push('py-2.5')
-    if(props.variant === 'outlined' && !props.label) base.push('py-2.5')
-    if(props.variant === 'underlined' && !props.label) base.push('pt-4 pb-1')
+    if(props.variant === 'filled' && !props.label && !slots.label) base.push('py-2.5')
+    if(props.variant === 'outlined' && !props.label && !slots.label) base.push('py-2.5')
+    if(props.variant === 'underlined' && !props.label && !slots.label) base.push('pt-4 pb-1')
     return base
 })
 
@@ -115,8 +117,8 @@ const iconClass = computed(() => {
 
 const clearIconClass = computed(() => {
     const base = ['pl-2']
-    if ( props.variant === 'filled' ) base.push(props.label ? 'pt-2' : '')
-    if ( props.variant === 'outlined' ) base.push(props.label ? 'pt-2' : '')
+    if ( props.variant === 'filled' ) base.push(props.label || slots.label ? 'pt-2' : '')
+    if ( props.variant === 'outlined' ) base.push(props.label || slots.label ? 'pt-2' : '')
     if ( props.variant === 'underlined' ) base.push('pt-3')
     return base
 })
@@ -158,7 +160,9 @@ const clear = () => {
             <label 
                 :class="labelClass"
             >
-                {{ label }}
+                <slot name="label">
+                    {{ label }}
+                </slot>
             </label>
         </div>
         <div v-show="clearIconDisplay" :class="clearIconClass">

--- a/src/components/form/CTextarea.story.vue
+++ b/src/components/form/CTextarea.story.vue
@@ -281,7 +281,7 @@ const error: {
 
 | Name | Props (if scoped) | Description |
 | --- | --- | --- |
-| - | - | このコンポーネント独自のSlotはありません |
+| label | - | ラベルの表示方法をカスタムします |
 
 ## Events
 

--- a/src/components/form/CTextarea.vue
+++ b/src/components/form/CTextarea.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import {computed} from 'vue';
+import {computed, useSlots} from 'vue';
 import { mdiClose } from '@mdi/js';
 import CSvgIcon from '@/components/images/CSvgIcon.vue';
+
+const slots = useSlots()
 
 const props = withDefaults(defineProps<{
     modelValue: any
@@ -80,11 +82,11 @@ const textareaClass = computed(() => {
     const base = [
         'peer block w-full appearance-none bg-transparent focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100',
     ]
-    if(!props.label) base.push('placeholder:opacity-100')
-    if(props.label && !props.modelValue) base.push('placeholder:opacity-0 focus:placeholder:opacity-100')
-    if(props.label && props.modelValue) base.push('placeholder:opacity-0')
-    if(props.variant === 'filled') base.push('min-h-[2.7rem]', props.label ?'pt-4 pb-1':'py-2.5')
-    if(props.variant === 'outlined') base.push('min-h-[2.8rem]', props.label ?'pt-4 pb-1':'py-2.5')
+    if(!props.label && !slots.label) base.push('placeholder:opacity-100')
+    if((props.label || slots.label) && !props.modelValue) base.push('placeholder:opacity-0 focus:placeholder:opacity-100')
+    if((props.label || slots.label) && props.modelValue) base.push('placeholder:opacity-0')
+    if(props.variant === 'filled') base.push('min-h-[2.7rem]', props.label || slots.label ?'pt-4 pb-1':'py-2.5')
+    if(props.variant === 'outlined') base.push('min-h-[2.8rem]', props.label || slots.label ?'pt-4 pb-1':'py-2.5')
     if(props.variant === 'underlined') base.push('min-h-[2.3rem] pt-4 pb-1')
 
     return base
@@ -145,8 +147,10 @@ const clear = () => {
             :placeholder="placeholder"
             :rows="rows"
             :class="textareaClass"/>
-            <label v-if="label" :class="labelClass">
-                {{ label }}
+            <label :class="labelClass">
+                <slot name="label">
+                    {{ label }}
+                </slot>
             </label>
         </div>
         <div class="pt-1 pr-1 self-start">


### PR DESCRIPTION
#220 

フォーム関連のラベルをslotで渡せるように修正しました。

## variantが`filled`の場合
<img width="527" alt="スクリーンショット 2023-08-30 16 06 48" src="https://github.com/actier-luchta/cuv/assets/101681088/96858f89-f62f-4d01-bb53-5e5f901f5d41">

## variantが`outlined`の場合
<img width="517" alt="スクリーンショット 2023-08-30 16 07 08" src="https://github.com/actier-luchta/cuv/assets/101681088/2bf8299a-2647-408a-bda0-099b7a2cb15c">

## variantが`underlined`の場合
<img width="512" alt="スクリーンショット 2023-08-30 16 07 15" src="https://github.com/actier-luchta/cuv/assets/101681088/842ae05a-0df4-4792-b755-b80f6fbb3229">
