### PR TITLE
CDataTable：[item.${header.key}]スロットの引数を修正

### DIFF
--- a/src/components/dataDisplay/CDataTable.story.vue
+++ b/src/components/dataDisplay/CDataTable.story.vue
@@ -554,8 +554,8 @@ onMounted(() => {
         @click:row="logEvent('click:row', $event)"
         >
             <template v-slot:[`item.group`]="{item}">
-                <CChip :color="setGroupColor(item)" size="small">
-                    {{ item }}
+                <CChip :color="setGroupColor(item.value)" size="small">
+                    {{ item.value }}
                 </CChip>
             </template>
         </CDataTable>
@@ -706,7 +706,7 @@ onMounted(() => {
 
 | Name | Props (if scoped) | Description |
 | --- | --- | --- |
-| [`item.${header.key}`] | `{index: number, item: any}` | 動的slotを使用して特定の列の表示をカスタムできます。`header.key`はheader項目のキー`<key>`プロパティの名前を指定します |
+| [`item.${header.key}`] | `{index: number, item: {value: any, key: string, raw: any}}` | 動的slotを使用して特定の列の表示をカスタムできます。`header.key`はheader項目のキー`<key>`プロパティの名前を指定します |
 | bottom | ItemProps* | tableの下部に表示するコンテンツを指定します |
 | default | ItemProps* | tableに表示するコンテンツを指定します |
 | tbody | ItemProps* | tbodyタグ内に表示するコンテンツを指定します |

--- a/src/components/dataDisplay/CDataTable.story.vue
+++ b/src/components/dataDisplay/CDataTable.story.vue
@@ -706,7 +706,7 @@ onMounted(() => {
 
 | Name | Props (if scoped) | Description |
 | --- | --- | --- |
-| [`item.${header.key}`] | `{index: number, item: {value: any, key: string, raw: any}}` | 動的slotを使用して特定の列の表示をカスタムできます。`header.key`はheader項目のキー`<key>`プロパティの名前を指定します |
+| [`item.${header.key}`] | `{index: number, item: {value: any, key: string, columns: any}}` | 動的slotを使用して特定の列の表示をカスタムできます。`header.key`はheader項目のキー`<key>`プロパティの名前を指定します |
 | bottom | ItemProps* | tableの下部に表示するコンテンツを指定します |
 | default | ItemProps* | tableに表示するコンテンツを指定します |
 | tbody | ItemProps* | tbodyタグ内に表示するコンテンツを指定します |

--- a/src/components/dataDisplay/CDataTable.story.vue
+++ b/src/components/dataDisplay/CDataTable.story.vue
@@ -706,7 +706,7 @@ onMounted(() => {
 
 | Name | Props (if scoped) | Description |
 | --- | --- | --- |
-| [`item.${header.key}`] | `{index: number, item: {value: any, key: string, columns: any}}` | 動的slotを使用して特定の列の表示をカスタムできます。`header.key`はheader項目のキー`<key>`プロパティの名前を指定します |
+| [`item.${header.key}`] | `{index: number, item: {key: string, value: any, columns: any}}` | 動的slotを使用して特定の列の表示をカスタムできます。`header.key`はheader項目のキー`<key>`プロパティの名前を指定します |
 | bottom | ItemProps* | tableの下部に表示するコンテンツを指定します |
 | default | ItemProps* | tableに表示するコンテンツを指定します |
 | tbody | ItemProps* | tbodyタグ内に表示するコンテンツを指定します |

--- a/src/components/dataDisplay/CDataTable.vue
+++ b/src/components/dataDisplay/CDataTable.vue
@@ -277,8 +277,15 @@ watchEffect(() => {
                     <td v-show="showSelect" class="text-center">
                         <CCheckbox v-model="data.selectItems" :value="item[itemValue]" @change="changeCheckbox" :disabled="!isSelectItem(item)" />
                     </td>
-                    <td v-for="(header, index) in headers" :key="index" @click="emits('click:row', item[itemValue])" :class="headerAlign(header.align)">
-                        <slot :name="[`item.${header.key}`]" :item="item[header.key]" :index="index">
+                    <td v-for="header in headers" :key="header.key" @click="emits('click:row', item[itemValue])" :class="headerAlign(header.align)">
+                        <slot 
+                        :name="[`item.${header.key}`]" 
+                        :item="{
+                            value:item[header.key],
+                            key: header.key,
+                            raw: item
+                            }" 
+                        :index="index">
                             {{ item[header.key] }}
                         </slot>
                     </td>

--- a/src/components/dataDisplay/CDataTable.vue
+++ b/src/components/dataDisplay/CDataTable.vue
@@ -283,7 +283,7 @@ watchEffect(() => {
                         :item="{
                             value:item[header.key],
                             key: header.key,
-                            raw: item
+                            columns: item
                             }" 
                         :index="index">
                             {{ item[header.key] }}

--- a/src/components/dataDisplay/CDataTable.vue
+++ b/src/components/dataDisplay/CDataTable.vue
@@ -281,8 +281,8 @@ watchEffect(() => {
                         <slot 
                         :name="[`item.${header.key}`]" 
                         :item="{
-                            value:item[header.key],
                             key: header.key,
+                            value:item[header.key],
                             columns: item
                             }" 
                         :index="index">


### PR DESCRIPTION
#221

CDataTableの、[item.${header.key}]スロットについて、以下修正を行いました。

- index→正しい値を返すように修正
- item→stringではなくobjectを返すように修正
```
//例
item: {
  key: 'group',
  value: '営業部',
  columns: { 
    "id": "004", 
    "name": "目黒四郎", 
    "date": "2023/01/01 10:01", 
    "group": "営業部", 
    "selectable": true 
    }, //行の項目値を全て渡す
}
```