### PR TITLE
github componets version up.

### DIFF
--- a/.github/workflows/histoire-gh-pages.yml
+++ b/.github/workflows/histoire-gh-pages.yml
@@ -25,19 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
       - name: Setup Node
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
-      - uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            node-
+          cache: 'npm'
       - name: Install and Build
         run: |
           npm ci
@@ -45,7 +40,7 @@ jobs:
       - name: .nojekyll
         run: touch .histoire/dist/.nojekyll
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: .histoire/dist/
 
@@ -59,4 +54,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
github actions の components が利用するバージョンを修正。

全て最新にせずに動作できるようにするレベルですが main にマージしないと動作がわからないので、マージして動作確認とします。